### PR TITLE
refactor: Controller-Duplikate in Trait extrahiert, XMP-Parsing konso…

### DIFF
--- a/lib/Controller/GalleryController.php
+++ b/lib/Controller/GalleryController.php
@@ -26,6 +26,8 @@ use Psr\Log\LoggerInterface;
 
 class GalleryController extends Controller
 {
+    use StarRateControllerTrait;
+
     // Unterstützte Bildformate
     private const SUPPORTED_MIME = [
         'image/jpeg',
@@ -89,10 +91,9 @@ class GalleryController extends Controller
     #[NoAdminRequired]
     public function images(): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $path  = $this->request->getParam('path', '/');
         $sort  = $this->request->getParam('sort', 'name');   // name | mtime | size
@@ -159,10 +160,9 @@ class GalleryController extends Controller
     #[NoCSRFRequired]
     public function thumbnail(int $fileId): Response
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $width  = (int) ($this->request->getParam('width', 300));
         $height = (int) ($this->request->getParam('height', 300));
@@ -202,10 +202,9 @@ class GalleryController extends Controller
     #[NoCSRFRequired]
     public function preview(int $fileId): Response
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $width  = (int) ($this->request->getParam('width', 1920));
         $height = (int) ($this->request->getParam('height', 1200));
@@ -282,25 +281,4 @@ class GalleryController extends Controller
         return array_values($images);
     }
 
-    /**
-     * Sucht eine Datei anhand der ID im User-Ordner.
-     */
-    private function getFileById(string $userId, int $fileId): ?File
-    {
-        $userFolder = $this->rootFolder->getUserFolder($userId);
-        $nodes      = $userFolder->getById($fileId);
-
-        foreach ($nodes as $node) {
-            if ($node instanceof File) {
-                return $node;
-            }
-        }
-        return null;
-    }
-
-    private function getUserId(): ?string
-    {
-        $user = $this->userSession->getUser();
-        return $user?->getUID();
-    }
 }

--- a/lib/Controller/RatingController.php
+++ b/lib/Controller/RatingController.php
@@ -18,6 +18,8 @@ use Psr\Log\LoggerInterface;
 
 class RatingController extends Controller
 {
+    use StarRateControllerTrait;
+
     public function __construct(
         string                        $appName,
         IRequest                      $request,
@@ -40,10 +42,9 @@ class RatingController extends Controller
     #[NoAdminRequired]
     public function get(int $fileId): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $file = $this->getFileById($userId, $fileId);
         if ($file === null) {
@@ -73,10 +74,9 @@ class RatingController extends Controller
     #[NoAdminRequired]
     public function set(int $fileId): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $body = $this->getJsonBody();
 
@@ -147,10 +147,9 @@ class RatingController extends Controller
     #[NoAdminRequired]
     public function setBatch(): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $body = $this->getJsonBody();
 
@@ -231,10 +230,9 @@ class RatingController extends Controller
     #[NoAdminRequired]
     public function delete(int $fileId): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $file = $this->getFileById($userId, $fileId);
         if ($file === null) {
@@ -286,26 +284,4 @@ class RatingController extends Controller
         return $errors;
     }
 
-    private function getJsonBody(): array
-    {
-        $params = $this->request->getParams();
-        return is_array($params) ? $params : [];
-    }
-
-    private function getFileById(string $userId, int $fileId): ?File
-    {
-        $userFolder = $this->rootFolder->getUserFolder($userId);
-        $nodes      = $userFolder->getById($fileId);
-        foreach ($nodes as $node) {
-            if ($node instanceof File) {
-                return $node;
-            }
-        }
-        return null;
-    }
-
-    private function getUserId(): ?string
-    {
-        return $this->userSession->getUser()?->getUID();
-    }
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -14,6 +14,8 @@ use OCP\IUserSession;
 
 class SettingsController extends Controller
 {
+    use StarRateControllerTrait;
+
     public function __construct(
         string                        $appName,
         IRequest                      $request,
@@ -27,10 +29,10 @@ class SettingsController extends Controller
     #[NoAdminRequired]
     public function getSettings(): DataResponse
     {
-        $userId = $this->userSession->getUser()?->getUID();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
+
         return new DataResponse($this->userSettings->getSettings($userId));
     }
 
@@ -38,16 +40,11 @@ class SettingsController extends Controller
     #[NoAdminRequired]
     public function saveSettings(): DataResponse
     {
-        $userId = $this->userSession->getUser()?->getUID();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
-        $raw  = file_get_contents('php://input');
-        $data = json_decode($raw ?: '{}', true);
-        if (!is_array($data)) {
-            return new DataResponse(['error' => 'Ungültiger JSON-Body'], Http::STATUS_BAD_REQUEST);
-        }
+        $data = $this->getJsonBody();
 
         try {
             $this->userSettings->saveSettings($userId, $data);

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -19,6 +19,8 @@ use Psr\Log\LoggerInterface;
 
 class ShareController extends Controller
 {
+    use StarRateControllerTrait;
+
     public function __construct(
         string                        $appName,
         IRequest                      $request,
@@ -46,10 +48,9 @@ class ShareController extends Controller
     #[NoAdminRequired]
     public function create(): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $body   = $this->getJsonBody();
         $errors = $this->validateShareBody($body);
@@ -82,10 +83,9 @@ class ShareController extends Controller
     #[NoAdminRequired]
     public function list(): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         try {
             $shares = $this->shareService->getSharesByOwner($userId);
@@ -102,10 +102,9 @@ class ShareController extends Controller
     #[NoAdminRequired]
     public function get(string $token): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         try {
             $share = $this->shareService->getShare($token);
@@ -125,10 +124,9 @@ class ShareController extends Controller
     #[NoAdminRequired]
     public function update(string $token): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $body  = $this->getJsonBody();
         $share = $this->shareService->getShare($token);
@@ -154,10 +152,9 @@ class ShareController extends Controller
     #[NoAdminRequired]
     public function delete(string $token): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $share = $this->shareService->getShare($token);
         if ($share === null || $share['owner_id'] !== $userId) {
@@ -181,10 +178,9 @@ class ShareController extends Controller
     #[NoAdminRequired]
     public function getLog(string $token): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $share = $this->shareService->getShare($token);
         if ($share === null || $share['owner_id'] !== $userId) {
@@ -203,10 +199,9 @@ class ShareController extends Controller
     #[NoAdminRequired]
     public function deleteLog(string $token): DataResponse
     {
-        $userId = $this->getUserId();
-        if ($userId === null) {
-            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
-        }
+        $auth = $this->requireAuth();
+        if ($auth instanceof DataResponse) return $auth;
+        $userId = $auth;
 
         $share = $this->shareService->getShare($token);
         if ($share === null || $share['owner_id'] !== $userId) {
@@ -484,15 +479,4 @@ class ShareController extends Controller
         return $errors;
     }
 
-    private function getJsonBody(): array
-    {
-        $raw     = file_get_contents('php://input');
-        $decoded = json_decode($raw ?: '{}', true);
-        return is_array($decoded) ? $decoded : [];
-    }
-
-    private function getUserId(): ?string
-    {
-        return $this->userSession->getUser()?->getUID();
-    }
 }

--- a/lib/Controller/StarRateControllerTrait.php
+++ b/lib/Controller/StarRateControllerTrait.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\StarRate\Controller;
+
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\Files\File;
+
+/**
+ * Gemeinsame Hilfsmethoden für alle StarRate-Controller.
+ *
+ * Erwartet, dass die nutzende Klasse folgende Properties besitzt:
+ *   - $this->userSession  (IUserSession)
+ *   - $this->rootFolder   (IRootFolder)       — nur wenn getFileById() genutzt wird
+ *   - $this->request      (IRequest)           — via Controller-Basisklasse
+ */
+trait StarRateControllerTrait
+{
+    /**
+     * Gibt die UID des eingeloggten Benutzers zurück (null wenn nicht authentifiziert).
+     */
+    private function getUserId(): ?string
+    {
+        return $this->userSession->getUser()?->getUID();
+    }
+
+    /**
+     * Prüft Authentifizierung und gibt die userId zurück.
+     * Gibt eine 401-DataResponse zurück falls nicht eingeloggt.
+     *
+     * Nutzung:
+     *   $auth = $this->requireAuth();
+     *   if ($auth instanceof DataResponse) return $auth;
+     *   $userId = $auth;
+     *
+     * @return string|DataResponse
+     */
+    private function requireAuth(): string|DataResponse
+    {
+        $userId = $this->getUserId();
+        if ($userId === null) {
+            return new DataResponse(['error' => 'Nicht authentifiziert'], Http::STATUS_UNAUTHORIZED);
+        }
+        return $userId;
+    }
+
+    /**
+     * Sucht eine Datei anhand der ID im User-Ordner.
+     */
+    private function getFileById(string $userId, int $fileId): ?File
+    {
+        $userFolder = $this->rootFolder->getUserFolder($userId);
+        $nodes      = $userFolder->getById($fileId);
+        foreach ($nodes as $node) {
+            if ($node instanceof File) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Liest den JSON-Body des Requests als assoziatives Array.
+     * Nutzt php://input direkt, da $this->request->getParams() auch
+     * NC-interne Route-Parameter enthält, die Validierungen stören können.
+     */
+    private function getJsonBody(): array
+    {
+        $raw     = file_get_contents('php://input');
+        $decoded = json_decode($raw ?: '{}', true);
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/lib/Service/ExifService.php
+++ b/lib/Service/ExifService.php
@@ -24,19 +24,14 @@ class ExifService
     private const XMP_NAMESPACE  = 'http://ns.adobe.com/xap/1.0/';
     private const XMP_MAGIC      = "http://ns.adobe.com/xap/1.0/\x00";
 
-    // Lightroom-kompatible Label-Namen
-    public const LABEL_MAP = [
-        'Red'    => 'Red',
-        'Yellow' => 'Yellow',
-        'Green'  => 'Green',
-        'Blue'   => 'Blue',
-        'Purple' => 'Purple',
-    ];
+    // Lightroom-kompatible Label-Namen (kanonische Quelle: XmpService::LABEL_MAP)
+    public const LABEL_MAP = XmpService::LABEL_MAP;
 
     // Maximale Dateigröße für direktes In-Memory-Bearbeiten (50 MB)
     private const MAX_MEMORY_SIZE = 52_428_800;
 
     public function __construct(
+        private readonly XmpService      $xmpService,
         private readonly LoggerInterface $logger,
     ) {}
 
@@ -192,45 +187,13 @@ class ExifService
 
     /**
      * Parst einen XMP-String und extrahiert Rating und Label.
+     * Delegiert an XmpService::parseXmpContent().
      *
      * @return array{rating: int, label: string|null}
      */
     private function parseXmp(string $xmp): array
     {
-        $rating = 0;
-        $label  = null;
-
-        // xmp:Rating als Attribut: xmp:Rating='5' oder xmp:Rating="5"
-        if (preg_match('/xmp:Rating\s*=\s*[\'"](\d+)[\'"]/', $xmp, $m)) {
-            $val = (int) $m[1];
-            if ($val >= 0 && $val <= 5) {
-                $rating = $val;
-            }
-        }
-        // xmp:Rating als Element: <xmp:Rating>5</xmp:Rating>
-        elseif (preg_match('/<xmp:Rating>(\d+)<\/xmp:Rating>/', $xmp, $m)) {
-            $val = (int) $m[1];
-            if ($val >= 0 && $val <= 5) {
-                $rating = $val;
-            }
-        }
-
-        // xmp:Label als Attribut
-        if (preg_match('/xmp:Label\s*=\s*[\'"]([^\'"]+)[\'"]/', $xmp, $m)) {
-            $val = trim($m[1]);
-            if (isset(self::LABEL_MAP[$val])) {
-                $label = $val;
-            }
-        }
-        // xmp:Label als Element
-        elseif (preg_match('/<xmp:Label>([^<]+)<\/xmp:Label>/', $xmp, $m)) {
-            $val = trim($m[1]);
-            if (isset(self::LABEL_MAP[$val])) {
-                $label = $val;
-            }
-        }
-
-        return ['rating' => $rating, 'label' => $label];
+        return $this->xmpService->parseXmpContent($xmp);
     }
 
     // ─── XMP schreiben ────────────────────────────────────────────────────────
@@ -250,24 +213,11 @@ class ExifService
 
     /**
      * Baut ein vollständiges XMP-Paket als String.
+     * Delegiert an XmpService::buildXmpContent().
      */
     private function buildXmpPacket(int $rating, ?string $label): string
     {
-        $ratingAttr = "xmp:Rating=\"{$rating}\"";
-        $labelAttr  = $label ? "\n      xmp:Label=\"{$label}\"" : '';
-
-        return <<<XMP
-<?xpacket begin='\xEF\xBB\xBF' id='W5M0MpCehiHzreSzNTczkc9d'?>
-<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='StarRate 1.0'>
-  <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <rdf:Description rdf:about=''
-      xmlns:xmp='http://ns.adobe.com/xap/1.0/'
-      {$ratingAttr}{$labelAttr}>
-    </rdf:Description>
-  </rdf:RDF>
-</x:xmpmeta>
-<?xpacket end='w'?>
-XMP;
+        return $this->xmpService->buildXmpContent($rating, $label);
     }
 
     /**

--- a/lib/Service/XmpService.php
+++ b/lib/Service/XmpService.php
@@ -21,6 +21,15 @@ use Psr\Log\LoggerInterface;
  */
 class XmpService
 {
+    // Lightroom-kompatible Label-Namen
+    public const LABEL_MAP = [
+        'Red'    => 'Red',
+        'Yellow' => 'Yellow',
+        'Green'  => 'Green',
+        'Blue'   => 'Blue',
+        'Purple' => 'Purple',
+    ];
+
     // RAW-Formate die per Sidecar verwaltet werden
     public const RAW_EXTENSIONS = ['cr3', 'cr2', 'nef', 'arw', 'orf', 'rw2', 'dng', 'raf', 'pef', 'srw'];
 
@@ -280,7 +289,7 @@ XMP;
         }
 
         // xmp:Label als Attribut oder Element
-        $validLabels = ExifService::LABEL_MAP;
+        $validLabels = self::LABEL_MAP;
         if (preg_match('/xmp:Label\s*=\s*[\'"]([^\'"]+)[\'"]/', $xmp, $m)) {
             $val = trim($m[1]);
             $label = isset($validLabels[$val]) ? $val : null;

--- a/tests/Unit/Service/ExifServiceTest.php
+++ b/tests/Unit/Service/ExifServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\StarRate\Tests\Unit\Service;
 
 use OCA\StarRate\Service\ExifService;
+use OCA\StarRate\Service\XmpService;
 use OCP\Files\File;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -18,8 +19,9 @@ class ExifServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->logger  = $this->createMock(LoggerInterface::class);
-        $this->service = new ExifService($this->logger);
+        $this->logger     = $this->createMock(LoggerInterface::class);
+        $xmpService       = new XmpService($this->logger);
+        $this->service    = new ExifService($xmpService, $this->logger);
     }
 
     // ─── Hilfsmethoden ────────────────────────────────────────────────────────


### PR DESCRIPTION
…lidiert

- StarRateControllerTrait: getUserId(), requireAuth(), getFileById(), getJsonBody() aus 4 Controllern extrahiert (18× Auth-Check dedupliziert)
- ExifService: parseXmp() und buildXmpPacket() delegieren an XmpService
- LABEL_MAP kanonisch in XmpService, ExifService referenziert
- ExifServiceTest an neuen Konstruktor (XmpService-Dependency) angepasst