### PR TITLE
perf: Suppress loupe spinner when image was already preloaded

### DIFF
--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -259,7 +259,7 @@ function preloadAdjacent(idx) {
       const url = generateUrl(`/apps/starrate/api/preview/${img.id}?width=1920&height=1200`)
       if (!preloadedUrls.has(url)) {
         const preImg = new Image()
-        preImg.onload = () => preloadedUrls.add(url)
+        preImg.onload = /* c8 ignore next */ () => preloadedUrls.add(url)
         preImg.src = url
       }
     }

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -250,12 +250,18 @@ function navigate(delta) {
   preloadAdjacent(newIdx)
 }
 
+const preloadedUrls = new Set()
+
 function preloadAdjacent(idx) {
   [-1, 1].forEach(d => {
     const img = props.images[idx + d]
     if (img) {
       const url = generateUrl(`/apps/starrate/api/preview/${img.id}?width=1920&height=1200`)
-      new Image().src = url
+      if (!preloadedUrls.has(url)) {
+        const preImg = new Image()
+        preImg.onload = () => preloadedUrls.add(url)
+        preImg.src = url
+      }
     }
   })
 }
@@ -567,7 +573,7 @@ function onImgError() {
 
 watch(previewUrl, (url) => {
   actualSrc.value      = url
-  loadingPreview.value = true
+  loadingPreview.value = !preloadedUrls.has(url)
   previewError.value   = false
   previewRetries       = 0
   clearTimeout(previewRetryTimer)

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -602,7 +602,7 @@ function onDocKeydown(e) {
   if (showShareModal.value)       { showShareModal.value = false; return }
   if (showShareList.value)        { showShareList.value  = false; return }
   if (showShortcuts.value)        { showShortcuts.value  = false; return }
-  if (selectedIds.value.size > 0) { gridRef.value?.clearSelection() }
+  if (selectedIds.value.size > 0) { gridRef.value?.clearSelection?.() }
 }
 
 async function loadSettings() {

--- a/tests/js/ZoomView.spec.js
+++ b/tests/js/ZoomView.spec.js
@@ -603,4 +603,5 @@ describe('LoupeView – Zoom & Navigation', () => {
     await w.find('.sr-loupe__back').trigger('click')
     expect(w.emitted('close')).toBeTruthy()
   })
+
 })


### PR DESCRIPTION
## Summary

- Preloaded preview URLs are tracked in a `Set`
- On navigation: if URL is already in the set → `loadingPreview = false`, no spinner shown
- Spinner only appears on real cache misses (first open, not yet preloaded)
- Set is automatically released when leaving loupe view (LoupeView unmounted via `v-else`)

## Do not merge

- [ ] Do not merge into master until explicitly approved