### PR TITLE
feat: occ starrate:import-xmp command (Issue #19)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -83,6 +83,10 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
         </navigation>
     </navigations>
 
+    <commands>
+        <command>OCA\StarRate\Command\ImportXmpCommand</command>
+    </commands>
+
     <settings>
         <personal-section>OCA\StarRate\Settings\PersonalSection</personal-section>
         <personal>OCA\StarRate\Settings\UserSettings</personal>

--- a/lib/Command/ImportXmpCommand.php
+++ b/lib/Command/ImportXmpCommand.php
@@ -150,12 +150,14 @@ class ImportXmpCommand extends Command
                 $label = $xmp['label'] ?? null;
 
                 if ($dryRun) {
-                    $output->writeln(sprintf(
-                        '  <info>import</info> %s  rating=%d  label=%s',
-                        $file->getName(),
-                        $xmp['rating'],
-                        $label ?? '—'
-                    ));
+                    if ($output->isVerbose()) {
+                        $output->writeln(sprintf(
+                            '  <info>import</info> %s  rating=%d  label=%s',
+                            $file->getName(),
+                            $xmp['rating'],
+                            $label ?? '—'
+                        ));
+                    }
                     $imported++;
                     continue;
                 }
@@ -166,12 +168,14 @@ class ImportXmpCommand extends Command
                     'color'  => $label,          // null = kein Label (löscht vorhandenes)
                 ]);
 
-                $output->writeln(sprintf(
-                    '  <info>import</info> %s  rating=%d  label=%s',
-                    $file->getName(),
-                    $xmp['rating'],
-                    $label ?? '—'
-                ));
+                if ($output->isVerbose()) {
+                    $output->writeln(sprintf(
+                        '  <info>import</info> %s  rating=%d  label=%s',
+                        $file->getName(),
+                        $xmp['rating'],
+                        $label ?? '—'
+                    ));
+                }
                 $imported++;
 
             } catch (\Exception $e) {

--- a/lib/Command/ImportXmpCommand.php
+++ b/lib/Command/ImportXmpCommand.php
@@ -17,10 +17,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * occ starrate:import-xmp <nc-path> [--user=<uid>] [--dry-run] [--skip-existing]
+ * occ starrate:import-xmp <nc-path> [--user=<uid>] [--dry-run] [--overwrite]
  *
  * Liest xmp:Rating und xmp:Label aus JPEG-Dateien und schreibt sie
  * in die StarRate Collaborative Tags-Datenbank.
+ * Scannt nur die angegebene Ordner-Ebene (nicht rekursiv).
  *
  * Typischer Anwendungsfall: einmaliger Import einer bestehenden
  * Lightroom/digiKam-Bibliothek in StarRate.
@@ -66,8 +67,8 @@ class ImportXmpCommand extends Command
     {
         $ncPath       = $input->getArgument('nc-path');
         $userId       = $input->getOption('user');
-        $dryRun    = (bool) $input->getOption('dry-run');
-        $overwrite = (bool) $input->getOption('overwrite');
+        $dryRun       = (bool) $input->getOption('dry-run');
+        $overwrite    = (bool) $input->getOption('overwrite');
 
         if (!$userId) {
             $output->writeln('<error>--user is required</error>');

--- a/lib/Command/ImportXmpCommand.php
+++ b/lib/Command/ImportXmpCommand.php
@@ -56,9 +56,9 @@ class ImportXmpCommand extends Command
                 'Show what would be imported without making changes'
             )
             ->addOption(
-                'skip-existing', null,
+                'overwrite', null,
                 InputOption::VALUE_NONE,
-                'Skip files that already have a rating in StarRate'
+                'Overwrite existing StarRate ratings (default: skip already-rated files)'
             );
     }
 
@@ -66,8 +66,8 @@ class ImportXmpCommand extends Command
     {
         $ncPath       = $input->getArgument('nc-path');
         $userId       = $input->getOption('user');
-        $dryRun       = (bool) $input->getOption('dry-run');
-        $skipExisting = (bool) $input->getOption('skip-existing');
+        $dryRun    = (bool) $input->getOption('dry-run');
+        $overwrite = (bool) $input->getOption('overwrite');
 
         if (!$userId) {
             $output->writeln('<error>--user is required</error>');
@@ -130,8 +130,8 @@ class ImportXmpCommand extends Command
 
                 $fileId = (string) $file->getId();
 
-                // Bestehende StarRate-Bewertung prüfen
-                if ($skipExisting) {
+                // Bestehende StarRate-Bewertung prüfen (Standard: überspringen)
+                if (!$overwrite) {
                     $existing = $this->tagService->getMetadata($fileId);
                     if ($existing['rating'] > 0 || $existing['color'] !== null) {
                         $skipped++;

--- a/lib/Command/ImportXmpCommand.php
+++ b/lib/Command/ImportXmpCommand.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\StarRate\Command;
+
+use OCA\StarRate\Service\ExifService;
+use OCA\StarRate\Service\TagService;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * occ starrate:import-xmp <nc-path> [--user=<uid>] [--dry-run] [--skip-existing]
+ *
+ * Liest xmp:Rating und xmp:Label aus JPEG-Dateien und schreibt sie
+ * in die StarRate Collaborative Tags-Datenbank.
+ *
+ * Typischer Anwendungsfall: einmaliger Import einer bestehenden
+ * Lightroom/digiKam-Bibliothek in StarRate.
+ */
+class ImportXmpCommand extends Command
+{
+    public function __construct(
+        private readonly IRootFolder $rootFolder,
+        private readonly ExifService $exifService,
+        private readonly TagService  $tagService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('starrate:import-xmp')
+            ->setDescription('Import XMP ratings from JPEG files into StarRate')
+            ->addArgument(
+                'nc-path',
+                InputArgument::REQUIRED,
+                'NC folder path relative to user home (e.g. /Bilder/2024)'
+            )
+            ->addOption(
+                'user', 'u',
+                InputOption::VALUE_REQUIRED,
+                'Nextcloud user ID'
+            )
+            ->addOption(
+                'dry-run', null,
+                InputOption::VALUE_NONE,
+                'Show what would be imported without making changes'
+            )
+            ->addOption(
+                'skip-existing', null,
+                InputOption::VALUE_NONE,
+                'Skip files that already have a rating in StarRate'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ncPath       = $input->getArgument('nc-path');
+        $userId       = $input->getOption('user');
+        $dryRun       = (bool) $input->getOption('dry-run');
+        $skipExisting = (bool) $input->getOption('skip-existing');
+
+        if (!$userId) {
+            $output->writeln('<error>--user is required</error>');
+            return Command::FAILURE;
+        }
+
+        // Ordner auflösen
+        try {
+            $userFolder = $this->rootFolder->getUserFolder($userId);
+            $node       = $ncPath === '/' ? $userFolder : $userFolder->get(ltrim($ncPath, '/'));
+        } catch (NotFoundException) {
+            $output->writeln("<error>Folder not found: {$ncPath}</error>");
+            return Command::FAILURE;
+        }
+
+        if (!($node instanceof Folder)) {
+            $output->writeln("<error>Path is not a folder: {$ncPath}</error>");
+            return Command::FAILURE;
+        }
+
+        if ($dryRun) {
+            $output->writeln('<comment>[dry-run] No changes will be written.</comment>');
+        }
+
+        $imported  = 0;
+        $skipped   = 0;
+        $noXmp     = 0;
+        $errors    = 0;
+        $nonJpeg   = 0;
+        $processed = 0;
+
+        $files = $node->getDirectoryListing();
+        $total = count($files);
+        $output->writeln(sprintf('Scanning %d files in %s...', $total, $ncPath));
+
+        foreach ($files as $file) {
+            if (!($file instanceof File)) {
+                continue;
+            }
+
+            $processed++;
+            if ($processed % 100 === 0) {
+                $output->writeln(sprintf('  [%d/%d] ...', $processed, $total));
+            }
+
+            $mime = $file->getMimeType();
+            if (!in_array($mime, ['image/jpeg', 'image/jpg'], true)) {
+                $nonJpeg++;
+                continue;
+            }
+
+            try {
+                // XMP aus Datei lesen
+                $xmp = $this->exifService->readMetadata($file);
+
+                if ($xmp['rating'] === 0 && $xmp['label'] === null) {
+                    $noXmp++;
+                    continue;
+                }
+
+                $fileId = (string) $file->getId();
+
+                // Bestehende StarRate-Bewertung prüfen
+                if ($skipExisting) {
+                    $existing = $this->tagService->getMetadata($fileId);
+                    if ($existing['rating'] > 0 || $existing['color'] !== null) {
+                        $skipped++;
+                        if ($output->isVerbose()) {
+                            $output->writeln(sprintf(
+                                '  skip  %s (already rated: %d★ %s)',
+                                $file->getName(),
+                                $existing['rating'],
+                                $existing['color'] ?? '—'
+                            ));
+                        }
+                        continue;
+                    }
+                }
+
+                $label = $xmp['label'] ?? null;
+
+                if ($dryRun) {
+                    $output->writeln(sprintf(
+                        '  <info>import</info> %s  rating=%d  label=%s',
+                        $file->getName(),
+                        $xmp['rating'],
+                        $label ?? '—'
+                    ));
+                    $imported++;
+                    continue;
+                }
+
+                // In StarRate-Tags schreiben (xmp:Label → color)
+                $this->tagService->setMetadata($fileId, [
+                    'rating' => $xmp['rating'],
+                    'color'  => $label,          // null = kein Label (löscht vorhandenes)
+                ]);
+
+                $output->writeln(sprintf(
+                    '  <info>import</info> %s  rating=%d  label=%s',
+                    $file->getName(),
+                    $xmp['rating'],
+                    $label ?? '—'
+                ));
+                $imported++;
+
+            } catch (\Exception $e) {
+                $errors++;
+                $output->writeln(sprintf(
+                    '  <error>error</error>  %s: %s',
+                    $file->getName(),
+                    $e->getMessage()
+                ));
+            }
+        }
+
+        $output->writeln(sprintf(
+            '%s<comment>Done:</comment> %d imported, %d skipped (already rated), %d without XMP, %d non-JPEG, %d errors.',
+            $dryRun ? '[dry-run] ' : '',
+            $imported,
+            $skipped,
+            $noXmp,
+            $nonJpeg,
+            $errors
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/lib/Controller/GalleryController.php
+++ b/lib/Controller/GalleryController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OCA\StarRate\Controller;
 
-use OCA\StarRate\Service\ExifService;
 use OCA\StarRate\Service\TagService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -45,7 +44,6 @@ class GalleryController extends Controller
         private readonly IRootFolder  $rootFolder,
         private readonly IUserSession $userSession,
         private readonly TagService   $tagService,
-        private readonly ExifService  $exifService,
         private readonly IPreviewManager $previewManager,
         private readonly IURLGenerator   $urlGenerator,
         private readonly LoggerInterface $logger,

--- a/lib/Service/ExifService.php
+++ b/lib/Service/ExifService.php
@@ -78,7 +78,11 @@ class ExifService
             if (!$this->isJpeg($content)) {
                 return ['rating' => 0, 'label' => null];
             }
-            return $this->readXmpFromContent($content);
+            $xmp = $this->readXmpFromContent($content);
+            if ($xmp['rating'] === 0 && $xmp['label'] === null) {
+                return $this->readExifRatingFromContent($content);
+            }
+            return $xmp;
         } catch (\Exception $e) {
             $this->logger->warning("StarRate: failed to read metadata from {$file->getName()}: " . $e->getMessage());
             return ['rating' => 0, 'label' => null];
@@ -95,7 +99,11 @@ class ExifService
         if (!$this->isJpeg($content)) {
             return ['rating' => 0, 'label' => null];
         }
-        return $this->readXmpFromContent($content);
+        $xmp = $this->readXmpFromContent($content);
+        if ($xmp['rating'] === 0 && $xmp['label'] === null) {
+            return $this->readExifRatingFromContent($content);
+        }
+        return $xmp;
     }
 
     /**
@@ -202,6 +210,45 @@ class ExifService
         }
 
         return $this->parseXmp($xmpBlock);
+    }
+
+    /**
+     * Liest EXIF-Rating als Fallback wenn kein XMP vorhanden (z.B. digiKam-Bilder).
+     * EXIF kennt kein Farb-Label — label bleibt immer null.
+     *
+     * @return array{rating: int, label: string|null}
+     */
+    private function readExifRatingFromContent(string $content): array
+    {
+        if (!function_exists('exif_read_data')) {
+            return ['rating' => 0, 'label' => null];
+        }
+
+        // EXIF steht immer in den ersten Segmenten — 64 KB reichen aus.
+        // php://memory vermeidet Tempfile auf der Festplatte.
+        $tmp = fopen('php://memory', 'r+b');
+        if ($tmp === false) {
+            return ['rating' => 0, 'label' => null];
+        }
+
+        try {
+            fwrite($tmp, substr($content, 0, 65536));
+            rewind($tmp);
+            $exif = @exif_read_data($tmp, 'IFD0');
+        } finally {
+            fclose($tmp);
+        }
+
+        if (!is_array($exif) || !isset($exif['Rating'])) {
+            return ['rating' => 0, 'label' => null];
+        }
+
+        $rating = (int) $exif['Rating'];
+        if ($rating < 0 || $rating > 5) {
+            return ['rating' => 0, 'label' => null];
+        }
+
+        return ['rating' => $rating, 'label' => null];
     }
 
     /**

--- a/lib/Service/XmpService.php
+++ b/lib/Service/XmpService.php
@@ -21,13 +21,25 @@ use Psr\Log\LoggerInterface;
  */
 class XmpService
 {
-    // Lightroom-kompatible Label-Namen
+    // Lightroom-kompatible Label-Namen (kanonisch englisch)
     public const LABEL_MAP = [
         'Red'    => 'Red',
         'Yellow' => 'Yellow',
         'Green'  => 'Green',
         'Blue'   => 'Blue',
         'Purple' => 'Purple',
+    ];
+
+    // Lokalisierte Label-Namen → kanonisch englisch
+    // photoshop:LabelColor (immer Kleinbuchstaben EN) wird per strcasecmp aufgelöst,
+    // daher hier nur Varianten die NICHT bereits über LABEL_MAP greifen.
+    private const LABEL_ALIASES = [
+        // Deutsch (LR exportiert xmp:Label in der UI-Sprache)
+        'Rot'  => 'Red',
+        'Gelb' => 'Yellow',
+        'Grün' => 'Green',   // UTF-8: ü = 0xC3 0xBC
+        'Blau' => 'Blue',
+        'Lila' => 'Purple',
     ];
 
     // RAW-Formate die per Sidecar verwaltet werden
@@ -192,6 +204,10 @@ XMP;
     /**
      * Parst einen XMP-String und gibt Rating + Label zurück.
      *
+     * Label-Auflösung (Priorität hoch → niedrig):
+     *  1. photoshop:LabelColor  — LR-proprietär, immer lowercase EN (red/yellow/…)
+     *  2. xmp:Label             — Standard, sprachabhängig (Red/Rot/Rouge/…)
+     *
      * @return array{rating: int, label: string|null}
      */
     public function parseXmpContent(string $xmp): array
@@ -208,12 +224,18 @@ XMP;
             $rating = ($val >= 0 && $val <= 5) ? $val : 0;
         }
 
-        // xmp:Label als Attribut oder Element
-        // Case-insensitiver Vergleich: akzeptiert z.B. "red", "RED" (Issue #16)
-        if (preg_match('/xmp:Label\s*=\s*[\'"]([^\'"]+)[\'"]/', $xmp, $m)
-            || preg_match('/<xmp:Label>([^<]+)<\/xmp:Label>/', $xmp, $m)) {
-            $val   = trim($m[1]);
-            $label = $this->resolveLabel($val);
+        // photoshop:LabelColor (Prio 1) — immer lowercase EN, z.B. "red", "green"
+        if (preg_match('/photoshop:LabelColor\s*=\s*[\'"]([^\'"]+)[\'"]/', $xmp, $m)
+            || preg_match('/<photoshop:LabelColor>([^<]+)<\/photoshop:LabelColor>/', $xmp, $m)) {
+            $label = $this->resolveLabel(trim($m[1]));
+        }
+
+        // xmp:Label (Prio 2, nur wenn photoshop:LabelColor nicht aufgelöst)
+        // Sprachabhängig: akzeptiert EN (Red/red/RED) und DE (Rot/Gelb/Grün/…)
+        if ($label === null
+            && (preg_match('/xmp:Label\s*=\s*[\'"]([^\'"]+)[\'"]/', $xmp, $m)
+                || preg_match('/<xmp:Label>([^<]+)<\/xmp:Label>/', $xmp, $m))) {
+            $label = $this->resolveLabel(trim($m[1]));
         }
 
         return ['rating' => $rating, 'label' => $label];
@@ -221,21 +243,28 @@ XMP;
 
     /**
      * Normalisiert einen Label-String auf den kanonischen englischen Namen.
-     * Akzeptiert case-insensitive englische Varianten (red, RED, Red).
-     * Unbekannte Labels (z.B. lokalisierte LR-Labels) werden als null zurückgegeben.
+     * Akzeptiert:
+     *  - Englisch, case-insensitiv: red/Red/RED → Red
+     *  - Deutsch (LR UI-Sprache): Rot/Gelb/Grün/Blau/Lila → Red/Yellow/Green/Blue/Purple
+     * Unbekannte Werte → null.
      */
     private function resolveLabel(string $val): ?string
     {
-        // Exakter Treffer
+        // Exakter Treffer (kanonisch englisch)
         if (isset(self::LABEL_MAP[$val])) {
             return $val;
         }
 
-        // Case-insensitiver Fallback (z.B. "red" → "Red")
+        // Case-insensitiver englischer Fallback (z.B. "red" → "Red", "GREEN" → "Green")
         foreach (array_keys(self::LABEL_MAP) as $canonical) {
             if (strcasecmp($val, $canonical) === 0) {
                 return $canonical;
             }
+        }
+
+        // Alias-Map (z.B. deutsch: "Rot" → "Red", "Grün" → "Green")
+        if (isset(self::LABEL_ALIASES[$val])) {
+            return self::LABEL_ALIASES[$val];
         }
 
         return null;

--- a/src/components/ColorLabel.vue
+++ b/src/components/ColorLabel.vue
@@ -92,9 +92,9 @@ function onKeydown(e, color) {
   }
 }
 
-// Externes Setzen per Tastatürkürzel (6–9 für Rot–Blau)
+// Externes Setzen per Tastatürkürzel (6–9 für Rot–Blau, V für Lila)
 function setByShortcut(key) {
-  const map = { '6': 'Red', '7': 'Yellow', '8': 'Green', '9': 'Blue' }
+  const map = { '6': 'Red', '7': 'Yellow', '8': 'Green', '9': 'Blue', 'v': 'Purple', 'V': 'Purple' }
   if (map[key]) {
     toggle(map[key])
     return true

--- a/tests/Unit/Service/XmpServiceTest.php
+++ b/tests/Unit/Service/XmpServiceTest.php
@@ -131,6 +131,56 @@ XMP;
         $this->assertSame('Purple', $this->service->parseXmpContent("xmp:Label='PURPLE'")['label']);
     }
 
+    /** @dataProvider germanLabelProvider */
+    public function testParseXmpContentGermanLabels(string $deLabel, string $expected): void
+    {
+        $result = $this->service->parseXmpContent("xmp:Label='{$deLabel}'");
+        $this->assertSame($expected, $result['label']);
+    }
+
+    public static function germanLabelProvider(): array
+    {
+        return [
+            ['Rot',  'Red'],
+            ['Gelb', 'Yellow'],
+            ['Grün', 'Green'],
+            ['Blau', 'Blue'],
+            ['Lila', 'Purple'],
+        ];
+    }
+
+    /** @dataProvider photoshopLabelColorProvider */
+    public function testParseXmpContentPhotoshopLabelColor(string $psValue, string $expected): void
+    {
+        $result = $this->service->parseXmpContent("photoshop:LabelColor='{$psValue}'");
+        $this->assertSame($expected, $result['label']);
+    }
+
+    public static function photoshopLabelColorProvider(): array
+    {
+        return [
+            ['red',    'Red'],
+            ['yellow', 'Yellow'],
+            ['green',  'Green'],
+            ['blue',   'Blue'],
+            ['purple', 'Purple'],
+        ];
+    }
+
+    public function testPhotoshopLabelColorTakesPriorityOverXmpLabel(): void
+    {
+        // photoshop:LabelColor="green" + xmp:Label="Rot" → Green gewinnt
+        $xmp    = "photoshop:LabelColor='green' xmp:Label='Rot'";
+        $result = $this->service->parseXmpContent($xmp);
+        $this->assertSame('Green', $result['label']);
+    }
+
+    public function testXmpLabelUsedWhenPhotoshopLabelColorAbsent(): void
+    {
+        $result = $this->service->parseXmpContent("xmp:Rating='3' xmp:Label='Gelb'");
+        $this->assertSame('Yellow', $result['label']);
+    }
+
     // ─── Tests: Round-Trip (bauen + parsen) ───────────────────────────────────
 
     /** @dataProvider roundTripProvider */

--- a/tests/js/ColorLabel.spec.js
+++ b/tests/js/ColorLabel.spec.js
@@ -130,6 +130,8 @@ describe('ColorLabel', () => {
     ['7', 'Yellow'],
     ['8', 'Green'],
     ['9', 'Blue'],
+    ['V', 'Purple'],
+    ['v', 'Purple'],
   ])('setByShortcut("%s") setzt %s', (key, expected) => {
     const w = factory({ modelValue: null })
     const result = w.vm.setByShortcut(key)
@@ -148,12 +150,6 @@ describe('ColorLabel', () => {
     const result = w.vm.setByShortcut('5')
     expect(result).toBe(false)
     expect(w.emitted('update:modelValue')).toBeFalsy()
-  })
-
-  it('setByShortcut mit "V" gibt false zurück (nur 6-9 gemappt)', () => {
-    const w = factory({ modelValue: null })
-    const result = w.vm.setByShortcut('V')
-    expect(result).toBe(false)
   })
 
   // ── setColor Expose ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- New OCC command: `occ starrate:import-xmp <user> <folder>`
- Reads `xmp:Rating`, `xmp:Label`, `photoshop:LabelColor` and EXIF `Rating` from JPEG files
- Imports into StarRate's Collaborative Tags database
- Skips already-rated files by default; use `--overwrite` to force update
- Progress shown every 100 files; individual filenames only with `-v`
- Supports German label names (Rot, Gelb, Grün, Blau, Lila)
- Not recursive — one folder at a time

## Do not merge

- [ ] Do not merge into master until explicitly approved

## Closes

Closes #19