### PR TITLE
fix: batch rating debounce — prevents concurrent JPEG writes and conflict copies

### DIFF
--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -477,29 +477,45 @@ async function onRate(image, rating, color, pick) {
 
 // ─── Stapel-Bewertung ─────────────────────────────────────────────────────────
 
-async function onBatchRate(rating, color, pick) {
+// Debounce-State: mehrere schnelle Klicks (Stern + Farbe + Pick) werden zu einem
+// kombinierten API-Request zusammengeführt, um konkurrierende JPEG-Writes zu vermeiden.
+let _batchDebounceTimer = null
+let _pendingBatch = null
+
+function onBatchRate(rating, color, pick) {
   const ids = Array.from(selectedIds.value)
   if (ids.length === 0) return
 
-  const payload = { fileIds: ids }
-  if (rating !== undefined) payload.rating = rating
-  if (color  !== undefined) payload.color  = color
-  if (pick   !== undefined) payload.pick   = pick
-
-  // Bar-Anzeige synchron aktualisieren (auch bei Keyboard-Auslösung)
+  // Optimistischer UI-Update sofort (unabhängig vom Debounce)
   if (rating !== undefined) batchActiveRating.value = rating
   if (color  !== undefined) batchActiveColor.value  = color
   if (pick   !== undefined) batchActivePick.value   = pick
 
-  // Optimistisch
   ids.forEach(id => {
     const local = allImages.value.find(i => i.id === id)
     if (local) {
-      if (payload.rating !== undefined) local.rating = payload.rating
-      if (payload.color  !== undefined) local.color  = payload.color
-      if (payload.pick   !== undefined) local.pick   = payload.pick
+      if (rating !== undefined) local.rating = rating
+      if (color  !== undefined) local.color  = color
+      if (pick   !== undefined) local.pick   = pick
     }
   })
+
+  // Payload akkumulieren — mehrere Klicks innerhalb des Debounce-Fensters
+  // werden zu einem einzigen Request zusammengeführt.
+  if (!_pendingBatch) {
+    _pendingBatch = { fileIds: ids }
+  }
+  if (rating !== undefined) _pendingBatch.rating = rating
+  if (color  !== undefined) _pendingBatch.color  = color
+  if (pick   !== undefined) _pendingBatch.pick   = pick
+
+  clearTimeout(_batchDebounceTimer)
+  _batchDebounceTimer = setTimeout(() => _sendBatch(), 200)
+}
+
+async function _sendBatch() {
+  const payload = _pendingBatch
+  _pendingBatch = null
 
   // Grid-Focus zurückgeben (SelectionBar-Klick nimmt Focus vom Grid weg)
   await nextTick()
@@ -508,7 +524,7 @@ async function onBatchRate(rating, color, pick) {
   try {
     if (props.batchRateFn) {
       const { fileIds: _, ...ratingData } = payload
-      await props.batchRateFn(ids, ratingData)
+      await props.batchRateFn(payload.fileIds, ratingData)
     } else {
       const url = generateUrl('/apps/starrate/api/rating/batch')
       const { data } = await axios.post(url, payload)
@@ -517,7 +533,7 @@ async function onBatchRate(rating, color, pick) {
       }
     }
 
-    const bildText = n('starrate', '%n Bild', '%n Bilder', ids.length)
+    const bildText = n('starrate', '%n Bild', '%n Bilder', payload.fileIds.length)
     const stars = payload.rating !== undefined
       ? ' — ' + '★'.repeat(payload.rating) + (payload.rating < 5 ? '☆'.repeat(5 - payload.rating) : '')
       : ''

--- a/tests/js/Gallery.spec.js
+++ b/tests/js/Gallery.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { defineComponent } from 'vue'
@@ -99,6 +99,11 @@ describe('Gallery – onBatchRate', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   // ── Sterne ────────────────────────────────────────────────────────────────
@@ -109,6 +114,7 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [1, 2])
     await triggerBatchRate(w, 4, undefined, undefined)
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).toHaveBeenCalledWith(
@@ -123,6 +129,7 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [1])
     await triggerBatchRate(w, 0, undefined, undefined)
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).toHaveBeenCalledWith(
@@ -137,6 +144,7 @@ describe('Gallery – onBatchRate', () => {
 
     // Keine Auswahl gesetzt
     await triggerBatchRate(w, 3, undefined, undefined)
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).not.toHaveBeenCalled()
@@ -150,6 +158,7 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [1, 3])
     await triggerBatchRate(w, undefined, 'Green', undefined)
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).toHaveBeenCalledWith(
@@ -164,6 +173,7 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [2])
     await triggerBatchRate(w, undefined, null, undefined)
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).toHaveBeenCalledWith(
@@ -177,8 +187,8 @@ describe('Gallery – onBatchRate', () => {
     await flushPromises()
 
     await selectImages(w, [1, 2])
-    // SelectionBar emittiert ('rate', undefined, null) nach dem Fix
     await triggerSelectionBarRate(w, undefined, null)
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).toHaveBeenCalledWith(
@@ -193,6 +203,7 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [1])
     await triggerSelectionBarRate(w, undefined, 'Blue')
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     const payload = batchRateFn.mock.calls[0][1]
@@ -206,6 +217,7 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [1])
     await triggerSelectionBarRate(w, 3, undefined)
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     const payload = batchRateFn.mock.calls[0][1]
@@ -221,6 +233,7 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [1, 2])
     await triggerBatchRate(w, undefined, undefined, 'pick')
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).toHaveBeenCalledWith(
@@ -235,9 +248,30 @@ describe('Gallery – onBatchRate', () => {
 
     await selectImages(w, [3])
     await triggerBatchRate(w, undefined, undefined, 'reject')
+    vi.advanceTimersByTime(300)
     await flushPromises()
 
     expect(batchRateFn).toHaveBeenCalledWith([3], expect.objectContaining({ pick: 'reject' }))
+  })
+
+  // ── Debounce-Merge ────────────────────────────────────────────────────────
+
+  it('batch-rate: schnelle Stern+Farbe Klicks werden zu einem Request zusammengeführt', async () => {
+    const { w, batchRateFn } = factory()
+    await flushPromises()
+
+    await selectImages(w, [1, 2])
+    await triggerBatchRate(w, 3, undefined, undefined)  // Stern
+    await triggerBatchRate(w, undefined, 'Red', undefined)  // Farbe direkt danach
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    // Nur ein Request, kombiniert
+    expect(batchRateFn).toHaveBeenCalledTimes(1)
+    expect(batchRateFn).toHaveBeenCalledWith(
+      expect.arrayContaining([1, 2]),
+      expect.objectContaining({ rating: 3, color: 'Red' })
+    )
   })
 
   // ── Optimistisches Update ─────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Each click on a star, color, or pick button in the SelectionBar triggered a separate immediate API call. Three rapid clicks = three concurrent write requests to the same JPEG file, causing:

- **Inconsistent XMP**: only rating or only label written, not both
- **NC conflict copies**: `file (1).jpg`, `file (2).jpg` created by NC when detecting write conflicts

Discovered via real-world test: batch-setting 325 images to 1★ + Red + Pick created conflict copies and left most JPEGs with split metadata.

## Fix

`onBatchRate` now accumulates rapid clicks within a 200ms window into a single combined payload, sending one API request instead of three. The optimistic UI update remains immediate — only the API call is debounced.

```
click 1★  ─┐
click Red  ─┤ 200ms window → one request: { rating:1, color:'Red', pick:'pick' }
click Pick ─┘
```

## Tests

- All existing batch-rate tests updated to use `vi.useFakeTimers()` + `vi.advanceTimersByTime(300)`
- New test: rapid star+color clicks are merged into one request