### PR TITLE
feat: write_xmp setting — optionally disable XMP writes per user

### DIFF
--- a/lib/Controller/RatingController.php
+++ b/lib/Controller/RatingController.php
@@ -6,6 +6,7 @@ namespace OCA\StarRate\Controller;
 
 use OCA\StarRate\Service\ExifService;
 use OCA\StarRate\Service\TagService;
+use OCA\StarRate\Settings\UserSettings;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -27,6 +28,7 @@ class RatingController extends Controller
         private readonly IUserSession $userSession,
         private readonly TagService   $tagService,
         private readonly ExifService  $exifService,
+        private readonly UserSettings $userSettings,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
@@ -108,18 +110,18 @@ class RatingController extends Controller
             // 1. NC-Tags setzen
             $this->tagService->setMetadata($fileIdStr, $data);
 
-            // 2. JPEG-XMP schreiben (nur wenn JPEG) — non-fatal: Tags sind die primäre Quelle
+            // 2. JPEG-XMP schreiben — nur wenn JPEG und in den Einstellungen aktiviert
             $mime = $file->getMimeType();
-            if (in_array($mime, ['image/jpeg', 'image/jpg'], true)) {
+            if (in_array($mime, ['image/jpeg', 'image/jpg'], true)
+                && $this->userSettings->getSettings($userId)['write_xmp']) {
                 try {
                     $this->exifService->writeMetadata(
                         $file,
-                        isset($data['rating']) ? $data['rating'] : null,
+                        $data['rating'] ?? null,
                         array_key_exists('color', $data) ? ($data['color'] ?? '') : null,
                     );
                 } catch (\Exception $e) {
-                    // XMP write failed (e.g. concurrent write / file lock) — tags already set, not fatal
-                    $this->logger->warning("StarRate: XMP write skipped for {$fileId} (concurrent write?): " . $e->getMessage());
+                    $this->logger->warning("StarRate: XMP write skipped for {$fileId}: " . $e->getMessage());
                 }
             }
 
@@ -202,9 +204,10 @@ class RatingController extends Controller
                 // NC-Tags
                 $this->tagService->setMetadata((string) $fileId, $data);
 
-                // JPEG-XMP — non-fatal
+                // JPEG-XMP — non-fatal, nur wenn in den Einstellungen aktiviert
                 $mime = $file->getMimeType();
-                if (in_array($mime, ['image/jpeg', 'image/jpg'], true)) {
+                if (in_array($mime, ['image/jpeg', 'image/jpg'], true)
+                    && $this->userSettings->getSettings($userId)['write_xmp']) {
                     try {
                         $this->exifService->writeMetadata(
                             $file,
@@ -258,7 +261,8 @@ class RatingController extends Controller
             $this->tagService->clearAll((string) $fileId);
 
             $mime = $file->getMimeType();
-            if (in_array($mime, ['image/jpeg', 'image/jpg'], true)) {
+            if (in_array($mime, ['image/jpeg', 'image/jpg'], true)
+                && $this->userSettings->getSettings($userId)['write_xmp']) {
                 $this->exifService->writeMetadata($file, 0, '');
             }
 

--- a/lib/Settings/UserSettings.php
+++ b/lib/Settings/UserSettings.php
@@ -68,6 +68,7 @@ class UserSettings implements ISettings
             'show_color_overlay'    => $this->getBool($userId, 'show_color_overlay', true),
             'grid_columns'          => $this->get($userId, 'grid_columns', 'auto'),
             'enable_pick_ui'        => $this->getBool($userId, 'enable_pick_ui', false),
+            'write_xmp'             => $this->getBool($userId, 'write_xmp', true),
         ];
     }
 
@@ -82,7 +83,7 @@ class UserSettings implements ISettings
         $allowed = [
             'default_sort', 'default_sort_order', 'thumbnail_size',
             'show_filename', 'show_rating_overlay',
-            'show_color_overlay', 'grid_columns', 'enable_pick_ui',
+            'show_color_overlay', 'grid_columns', 'enable_pick_ui', 'write_xmp',
         ];
 
         foreach ($data as $key => $value) {
@@ -122,7 +123,7 @@ class UserSettings implements ISettings
             'thumbnail_size' => $this->assertRange($key, (int) $value, 120, 600),
             'grid_columns' => $this->assertIn($key, $value, ['auto', '2', '3', '4', '5', '6', '8']),
             'show_filename', 'show_rating_overlay', 'show_color_overlay',
-            'enable_pick_ui' => null,
+            'enable_pick_ui', 'write_xmp' => null,
         };
     }
 

--- a/src/views/SettingsPanel.vue
+++ b/src/views/SettingsPanel.vue
@@ -85,6 +85,12 @@
           {{ t('starrate', 'Pick / Reject aktivieren') }}
         </label>
       </div>
+      <div class="sr-settings__row">
+        <label class="sr-settings__label sr-settings__label--check">
+          <input type="checkbox" v-model="form.write_xmp" @change="autosave" />
+          {{ t('starrate', 'XMP in JPEG schreiben') }}
+        </label>
+      </div>
     </div>
 
     <!-- Status -->
@@ -116,6 +122,7 @@ const DEFAULTS = {
   show_color_overlay:   true,
   grid_columns:        'auto',
   enable_pick_ui:       false,
+  write_xmp:            true,
 }
 
 const form   = reactive({ ...DEFAULTS, ...props.initial })


### PR DESCRIPTION
Adds a user setting to disable XMP writes to JPEG files.

## Why

After a one-time import with `occ starrate:import-xmp`, some users only want StarRate to manage ratings in NC tags — no JPEG modifications. This is especially useful only using ratings and Export Lists with the Client.

## What changed

- New boolean setting `write_xmp` (default: `true` — no change for existing users)
- When disabled, all three write paths in `RatingController` skip the XMP write:
  - Single rating (`POST /api/rating/{id}`)
  - Batch rating (`POST /api/rating/batch`)
  - Delete/clear (`DELETE /api/rating/{id}`)
- Toggle visible in personal settings under **Features** → "XMP in JPEG schreiben / Write XMP to JPEG"
- Guest shares are unaffected (they don't write XMP regardless)

## Notes

- NC tags remain the primary source of truth either way
- The `xmpSkipped`/`xmpWritten` batch response counters only count JPEG files where a write was attempted — files skipped due to this setting are not counted as errors