### PR TITLE
fix: write_xmp missing from Gallery settings default

### DIFF
--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -280,6 +280,7 @@ const settings = ref({
   show_color_overlay:   true,
   grid_columns:        'auto',
   enable_pick_ui:       false,
+  write_xmp:            true,
 })
 const subFolders   = ref([])
 const currentIndex = ref(0)


### PR DESCRIPTION
write_xmp was not in the Gallery settings default object, so guest mode (which never loads user settings) had it as undefined (falsy). The single-image toast wasn't showing for guests, breaking the Cypress E2E test.