### PR TITLE
fix: mobile breadcrumb truncation and ESC modal handling

### DIFF
--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -659,9 +659,9 @@ function onShareCreated() {
 // Escape auf Dokument-Ebene: schließt Modals von innen nach außen, dann Auswahl
 function onDocKeydown(e) {
   if (e.key !== 'Escape') return
-  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShareList.value)        { showShareList.value  = false; return }
+  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.stopPropagation(); return }
+  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.stopPropagation(); return }
+  if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.stopPropagation(); return }
   if (showShortcuts.value)        { showShortcuts.value  = false; return }
   if (selectedIds.value.size > 0) { gridRef.value?.clearSelection?.() }
 }
@@ -1121,5 +1121,14 @@ watch(() => route.query, q => {
   }
   .sr-breadcrumb__version { display: none; }
   .sr-breadcrumb__mode    { display: none; }
+
+  /* Pfad-Segmente dürfen schrumpfen und bei Platzmangel abschneiden,
+     damit Teilen/Export immer vollständig sichtbar bleiben */
+  .sr-breadcrumb__seg {
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 </style>


### PR DESCRIPTION
**Issue 1 — Mobile breadcrumb too wide**
Path segments (folder names) now truncate with ellipsis on mobile (max-width: 120px) so Teilen/Export buttons are always fully visible without horizontal scrolling past them.

**Issues 4+5 — ESC with ShareList open**
- Added blur() when ESC closes ShareList — prevents the Teilen button from staying highlighted for 1-2s after closing
- Added stopPropagation() to all three ESC-close handlers (ExportModal, ShareModal, ShareList) — prevents NC's own ESC handler from also firing (was causing focus to jump to the folder view instead of cleanly closing the panel)

Issues 2+3 (Export gray / not working) confirmed as expected behavior — button is disabled when the folder has no images.