### PR TITLE
fix: ESC capture phase — prevent NC folder navigation when modal is open

### DIFF
--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -659,9 +659,9 @@ function onShareCreated() {
 // Escape auf Dokument-Ebene: schließt Modals von innen nach außen, dann Auswahl
 function onDocKeydown(e) {
   if (e.key !== 'Escape') return
-  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.stopPropagation(); return }
-  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.stopPropagation(); return }
-  if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.stopPropagation(); return }
+  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.preventDefault(); e.stopPropagation(); return }
+  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.preventDefault(); e.stopPropagation(); return }
+  if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } e.preventDefault(); e.stopPropagation(); return }
   if (showShortcuts.value)        { showShortcuts.value  = false; return }
   if (selectedIds.value.size > 0) { gridRef.value?.clearSelection?.() }
 }


### PR DESCRIPTION
NC's own ESC handler runs in the bubble phase on the document. When ShareList, ShareModal or ExportModal is open and ESC is pressed, NC was navigating to the parent folder in the background while the modal stayed open.

Fix: register our keydown handler with `{ capture: true }` so it runs first, then call `stopImmediatePropagation()` to prevent any other handlers on document from firing.