### PR TITLE
chore: bump version to 1.2.5

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -44,7 +44,7 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 - Englisch und Deutsch
     ]]></description>
 
-    <version>1.2.4</version>
+    <version>1.2.5</version>
     <licence>agpl</licence>
 
     <author mail="starrate@merlin1.de" homepage="https://github.com/merlin1de/starrate">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrate",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "description": "Professionelles Foto-Bewertungs- und Lightroom-Sync-Tool für Nextcloud",
   "scripts": {


### PR DESCRIPTION
Version bump for nightly only — 1.2.4 remains in the NC App Store.