### PR TITLE
fix: comment UI round 2 — button position, flicker, ShareList toggle

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -228,6 +228,7 @@ OC.L10N.register(
         "XMP in JPEG schreiben" : "XMP in JPEG schreiben",
         "Kommentare aktivieren" : "Kommentare aktivieren",
         "Kommentare erlauben" : "Kommentare erlauben",
+    "Kommentare deaktivieren" : "Kommentare deaktivieren",
         "Kommentar" : "Kommentar",
         "Neuer Kommentar" : "Neuer Kommentar",
         "Kommentar hinzufügen..." : "Kommentar hinzufügen...",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -213,6 +213,7 @@
     "XMP in JPEG schreiben" : "XMP in JPEG schreiben",
     "Kommentare aktivieren" : "Kommentare aktivieren",
     "Kommentare erlauben" : "Kommentare erlauben",
+    "Kommentare deaktivieren" : "Kommentare deaktivieren",
     "Kommentar" : "Kommentar",
     "Neuer Kommentar" : "Neuer Kommentar",
     "Kommentar hinzufügen..." : "Kommentar hinzufügen...",

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -228,6 +228,7 @@ OC.L10N.register(
         "XMP in JPEG schreiben" : "Write XMP into JPEG",
         "Kommentare aktivieren" : "Enable comments",
         "Kommentare erlauben" : "Allow comments",
+    "Kommentare deaktivieren" : "Disable comments",
         "Kommentar" : "Comment",
         "Neuer Kommentar" : "New comment",
         "Kommentar hinzufügen..." : "Add a comment...",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -215,6 +215,7 @@
     "XMP in JPEG schreiben" : "Write XMP into JPEG",
     "Kommentare aktivieren" : "Enable comments",
     "Kommentare erlauben" : "Allow comments",
+    "Kommentare deaktivieren" : "Disable comments",
     "Kommentar" : "Comment",
     "Neuer Kommentar" : "New comment",
     "Kommentar hinzufügen..." : "Add a comment...",

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -97,22 +97,20 @@
       <div class="sr-loupe__footer" v-show="showControls">
         <div class="sr-loupe__footer-left">
           <span class="sr-loupe__filename">{{ currentImage?.name }}</span>
-          <div class="sr-loupe__footer-info">
-            <span class="sr-loupe__index">{{ currentIndex + 1 }} / {{ images.length }}</span>
-            <button
-              v-if="allowComment || commentsEnabledOwner"
-              class="sr-loupe__comment-btn"
-              :class="{ 'sr-loupe__comment-btn--active': hasComment }"
-              type="button"
-              :title="t('starrate', 'Kommentar')"
-              @click="openCommentSheet"
-            >
-              <svg viewBox="0 0 24 24" fill="none" style="width:14px;height:14px" aria-hidden="true">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </button>
-          </div>
+          <span class="sr-loupe__index">{{ currentIndex + 1 }} / {{ images.length }}</span>
         </div>
+        <button
+          v-if="allowComment || commentsEnabledOwner"
+          class="sr-loupe__comment-btn"
+          :class="{ 'sr-loupe__comment-btn--active': hasComment }"
+          type="button"
+          :title="t('starrate', 'Kommentar')"
+          @click="openCommentSheet"
+        >
+          <svg viewBox="0 0 24 24" fill="none" style="width:18px;height:18px" aria-hidden="true">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
         <div class="sr-loupe__footer-center">
           <RatingStars
             :model-value="currentImage?.rating ?? 0"
@@ -730,8 +728,13 @@ async function loadComment(fileId) {
   } catch { /* ignore */ }
 }
 
-function openCommentSheet() {
+async function openCommentSheet() {
   commentStatus.value = ''
+  // Falls Kommentar noch nicht geladen (z.B. beim allerersten Klick vor Resolve),
+  // kurz warten damit kein State-Sprung new → view entsteht.
+  if (!commentText.value && (props.allowComment || props.commentsEnabledOwner)) {
+    await loadComment(currentImage.value?.id)
+  }
   if (hasComment.value) {
     commentSheetState.value = 'view'
     commentDraft.value      = commentText.value
@@ -1046,12 +1049,6 @@ watch(() => props.initialIndex, idx => {
   text-overflow: ellipsis;
 }
 
-.sr-loupe__footer-info {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
 .sr-loupe__index {
   font-size: 11px;
   color: #666;
@@ -1178,11 +1175,11 @@ watch(() => props.initialIndex, idx => {
   border: none;
   color: #52525b;
   cursor: pointer;
-  padding: 2px;
-  display: inline-flex;
+  padding: 0 8px;
+  display: flex;
   align-items: center;
+  align-self: stretch;   /* nimmt die volle Höhe von footer-left */
   flex-shrink: 0;
-  line-height: 1;
   transition: color 0.15s;
 }
 .sr-loupe__comment-btn--active { color: #e94560; }

--- a/src/components/ShareList.vue
+++ b/src/components/ShareList.vue
@@ -62,6 +62,12 @@
                     :title="share.allow_export ? t('starrate', 'Export deaktivieren') : t('starrate', 'Export aktivieren')"
                     @click="toggleExport(share)"
                   >{{ share.allow_export ? '✓' : '✗' }} Export</span>
+                  <span
+                    class="sr-share-list__badge sr-share-list__badge--pick-click"
+                    :class="share.allow_comment ? 'sr-share-list__badge--pick-on' : 'sr-share-list__badge--pick-off'"
+                    :title="share.allow_comment ? t('starrate', 'Kommentare deaktivieren') : t('starrate', 'Kommentare aktivieren')"
+                    @click="toggleComment(share)"
+                  >{{ share.allow_comment ? '✓' : '✗' }} 💬</span>
                   <span v-if="share.expires_at" class="sr-share-list__badge" :class="isExpired(share) ? 'sr-share-list__badge--expired' : 'sr-share-list__badge--date'">
                     {{ isExpired(share) ? t('starrate', 'Abgelaufen') : formatDate(share.expires_at) }}
                   </span>
@@ -310,6 +316,17 @@ async function toggleExport(share) {
     const { data } = await axios.put(
       generateUrl(`/apps/starrate/api/share/${share.token}`),
       { allow_export: !share.allow_export }
+    )
+    const idx = shares.value.findIndex(s => s.token === share.token)
+    if (idx !== -1) shares.value[idx] = data.share
+  } catch { /* ignore */ }
+}
+
+async function toggleComment(share) {
+  try {
+    const { data } = await axios.put(
+      generateUrl(`/apps/starrate/api/share/${share.token}`),
+      { allow_comment: !share.allow_comment }
     )
     const idx = shares.value.findIndex(s => s.token === share.token)
     if (idx !== -1) shares.value[idx] = data.share


### PR DESCRIPTION
1. Comment button is now a sibling of footer-left, spanning its full height — right of both filename and index rows
2. openCommentSheet awaits loadComment if not yet resolved, prevents new→view state flash
3. allow_comment toggle badge in ShareList (same pattern as allow_pick/allow_export)