### PR TITLE
feat: Kommentare zu Fotos (#4) — UI, Backend, Tests

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -44,7 +44,7 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 - Englisch und Deutsch
     ]]></description>
 
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <licence>agpl</licence>
 
     <author mail="starrate@merlin1.de" homepage="https://github.com/merlin1de/starrate">

--- a/css/starrate-guest.css
+++ b/css/starrate-guest.css
@@ -1,3 +1,3 @@
 /* extracted by css-entry-points-plugin */
-@import './guest-B6ji-8Pj.chunk.css';
-@import './Gallery-B7lpgxY4.chunk.css';
+@import './guest-bR0Rjup5.chunk.css';
+@import './Gallery-Dg-KGQtK.chunk.css';

--- a/css/starrate-main.css
+++ b/css/starrate-main.css
@@ -1,2 +1,2 @@
 /* extracted by css-entry-points-plugin */
-@import './Gallery-B7lpgxY4.chunk.css';
+@import './Gallery-Dg-KGQtK.chunk.css';

--- a/css/starrate-settings.css
+++ b/css/starrate-settings.css
@@ -1,2 +1,2 @@
 /* extracted by css-entry-points-plugin */
-@import './settings-DiAha_so.chunk.css';
+@import './settings-Dfwdtc4m.chunk.css';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starrate",
-  "version": "1.0.0",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starrate",
-      "version": "1.0.0",
+      "version": "1.2.6",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/event-bus": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrate",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "description": "Professionelles Foto-Bewertungs- und Lightroom-Sync-Tool für Nextcloud",
   "scripts": {

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -95,25 +95,23 @@
     <!-- Untere Overlay: Dateiname + Rating + Farbe -->
     <Transition name="slide-up">
       <div class="sr-loupe__footer" v-show="showControls">
-        <!-- Wrapper: auf Desktop Zeilenblock + Button nebeneinander; auf Mobile als eigene Zeile -->
-        <div class="sr-loupe__left-group">
-          <div class="sr-loupe__footer-left">
-            <span class="sr-loupe__filename">{{ currentImage?.name }}</span>
-            <span class="sr-loupe__index">{{ currentIndex + 1 }} / {{ images.length }}</span>
-          </div>
-          <button
-            v-if="allowComment || commentsEnabledOwner"
-            class="sr-loupe__comment-btn"
-            :class="{ 'sr-loupe__comment-btn--active': hasComment }"
-            type="button"
-            :title="t('starrate', 'Kommentar')"
-            @click="openCommentSheet"
-          >
-            <svg viewBox="0 0 24 24" fill="none" style="width:18px;height:18px" aria-hidden="true">
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
+        <div class="sr-loupe__footer-left">
+          <span class="sr-loupe__filename">{{ currentImage?.name }}</span>
+          <span class="sr-loupe__index">{{ currentIndex + 1 }} / {{ images.length }}</span>
         </div>
+        <button
+          v-if="allowComment || commentsEnabledOwner"
+          class="sr-loupe__comment-btn"
+          :class="{ 'sr-loupe__comment-btn--active': hasComment }"
+          type="button"
+          :title="t('starrate', 'Kommentar')"
+          @click="openCommentSheet"
+        >
+          <svg class="sr-loupe__comment-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="sr-loupe__comment-label">{{ t('starrate', 'Kommentar') }}</span>
+        </button>
         <div class="sr-loupe__footer-center">
           <RatingStars
             :model-value="currentImage?.rating ?? 0"
@@ -150,74 +148,72 @@
       </div>
     </Transition>
 
-    <!-- Kommentar Bottom Sheet -->
-    <Transition name="sr-comment-sheet">
-      <div
-        v-if="commentSheetOpen"
-        class="sr-loupe__comment-sheet-overlay"
-        @click.self="closeCommentSheet"
-      >
-        <div class="sr-loupe__comment-sheet">
-          <div class="sr-loupe__comment-sheet-header">
-            <span class="sr-loupe__comment-meta">
-              <template v-if="commentAuthor && commentDate">
-                {{ commentAuthor }} · {{ formatCommentDate(commentDate) }}
-              </template>
-              <template v-else>
-                {{ t('starrate', 'Neuer Kommentar') }}
-              </template>
-            </span>
-            <button class="sr-loupe__comment-close" type="button" @click="closeCommentSheet">✕</button>
-          </div>
+    <!-- Kommentar Bottom Sheet (immer im DOM, CSS-only Transition) -->
+    <div
+      class="sr-loupe__comment-sheet-overlay"
+      :class="{ 'sr-loupe__comment-sheet-overlay--open': commentSheetOpen }"
+      @click.self="closeCommentSheet"
+    >
+      <div class="sr-loupe__comment-sheet">
+        <div class="sr-loupe__comment-sheet-header">
+          <span class="sr-loupe__comment-meta">
+            <template v-if="commentAuthor && commentDate">
+              {{ commentAuthor }} · {{ formatCommentDate(commentDate) }}
+            </template>
+            <template v-else>
+              {{ t('starrate', 'Neuer Kommentar') }}
+            </template>
+          </span>
+          <button class="sr-loupe__comment-close" type="button" @click="closeCommentSheet">✕</button>
+        </div>
 
-          <!-- View-Modus -->
-          <div v-if="commentSheetState === 'view'" class="sr-loupe__comment-body">
-            <p class="sr-loupe__comment-text">{{ commentText }}</p>
-            <div v-if="commentSheetState !== 'confirm-delete'" class="sr-loupe__comment-actions">
-              <button class="sr-loupe__comment-action" type="button" @click="commentSheetState = 'edit'; commentDraft = commentText">
-                <svg viewBox="0 0 24 24" fill="none" style="width:14px;height:14px" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-              </button>
-              <button class="sr-loupe__comment-action sr-loupe__comment-action--delete" type="button" @click="commentSheetState = 'confirm-delete'">
-                <svg viewBox="0 0 24 24" fill="none" style="width:14px;height:14px" aria-hidden="true"><polyline points="3 6 5 6 21 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M19 6l-1 14H6L5 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M10 11v6M14 11v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
-              </button>
-            </div>
+        <!-- View-Modus -->
+        <div v-if="commentSheetState === 'view'" class="sr-loupe__comment-body">
+          <p class="sr-loupe__comment-text">{{ commentText }}</p>
+          <div class="sr-loupe__comment-actions">
+            <button class="sr-loupe__comment-action" type="button" @click="commentSheetState = 'edit'; commentDraft = commentText">
+              <svg viewBox="0 0 24 24" fill="none" style="width:14px;height:14px" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <button class="sr-loupe__comment-action sr-loupe__comment-action--delete" type="button" @click="commentSheetState = 'confirm-delete'">
+              <svg viewBox="0 0 24 24" fill="none" style="width:14px;height:14px" aria-hidden="true"><polyline points="3 6 5 6 21 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M19 6l-1 14H6L5 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M10 11v6M14 11v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            </button>
           </div>
+        </div>
 
-          <!-- Löschen-Bestätigung -->
-          <div v-else-if="commentSheetState === 'confirm-delete'" class="sr-loupe__comment-body">
-            <p class="sr-loupe__comment-text">{{ commentText }}</p>
-            <div class="sr-loupe__comment-actions sr-loupe__comment-actions--confirm">
-              <button class="sr-loupe__comment-btn-cancel" type="button" @click="commentSheetState = 'view'">
-                {{ t('starrate', 'Abbrechen') }}
-              </button>
-              <button class="sr-loupe__comment-btn-save sr-loupe__comment-btn-save--danger" type="button"
-                      :disabled="commentSaving" @click="confirmDeleteComment">
-                {{ t('starrate', 'Ja, löschen') }}
-              </button>
-            </div>
+        <!-- Löschen-Bestätigung -->
+        <div v-else-if="commentSheetState === 'confirm-delete'" class="sr-loupe__comment-body">
+          <p class="sr-loupe__comment-text">{{ commentText }}</p>
+          <div class="sr-loupe__comment-actions sr-loupe__comment-actions--confirm">
+            <button class="sr-loupe__comment-btn-cancel" type="button" @click="commentSheetState = 'view'">
+              {{ t('starrate', 'Abbrechen') }}
+            </button>
+            <button class="sr-loupe__comment-btn-save sr-loupe__comment-btn-save--danger" type="button"
+                    :disabled="commentSaving" @click="confirmDeleteComment">
+              {{ t('starrate', 'Ja, löschen') }}
+            </button>
           </div>
+        </div>
 
-          <!-- Neu / Edit-Modus -->
-          <div v-else class="sr-loupe__comment-body">
-            <textarea
-              v-model="commentDraft"
-              class="sr-loupe__comment-textarea"
-              :placeholder="t('starrate', 'Kommentar hinzufügen...')"
-              rows="3"
-              maxlength="2000"
-            />
-            <div class="sr-loupe__comment-actions sr-loupe__comment-actions--edit">
-              <span v-if="commentStatus === 'ok'" class="sr-loupe__comment-status sr-loupe__comment-status--ok">✓</span>
-              <span v-if="commentStatus === 'error'" class="sr-loupe__comment-status sr-loupe__comment-status--error">✗</span>
-              <button class="sr-loupe__comment-btn-save" type="button"
-                      :disabled="commentSaving || !commentDraft.trim()" @click="saveComment">
-                {{ t('starrate', 'Speichern') }}
-              </button>
-            </div>
+        <!-- Neu / Edit-Modus -->
+        <div v-else class="sr-loupe__comment-body">
+          <textarea
+            v-model="commentDraft"
+            class="sr-loupe__comment-textarea"
+            :placeholder="t('starrate', 'Kommentar hinzufügen...')"
+            rows="3"
+            maxlength="2000"
+          />
+          <div class="sr-loupe__comment-actions sr-loupe__comment-actions--edit">
+            <span v-if="commentStatus === 'ok'" class="sr-loupe__comment-status sr-loupe__comment-status--ok">✓</span>
+            <span v-if="commentStatus === 'error'" class="sr-loupe__comment-status sr-loupe__comment-status--error">✗</span>
+            <button class="sr-loupe__comment-btn-save" type="button"
+                    :disabled="commentSaving || !commentDraft.trim()" @click="saveComment">
+              {{ t('starrate', 'Speichern') }}
+            </button>
           </div>
         </div>
       </div>
-    </Transition>
+    </div>
   </div>
 </template>
 
@@ -726,7 +722,7 @@ function loadComment(fileId) {
       } else if (props.commentsEnabledOwner) {
         const url = generateUrl(`/apps/starrate/api/rating/${fileId}/comment`)
         const { data } = await axios.get(url)
-        result = data.comment ?? null
+        result = data ?? null
       }
       if (result && typeof result === 'object') {
         commentText.value   = result.comment    ?? ''
@@ -756,7 +752,8 @@ async function openCommentSheet() {
   } else {
     commentSheetState.value = 'new'
     commentDraft.value      = ''
-    nextTick(() => document.querySelector('.sr-loupe__comment-textarea')?.focus())
+    // Focus erst nach CSS-Transition (200ms) um Reflow-Jitter zu vermeiden
+    setTimeout(() => document.querySelector('.sr-loupe__comment-textarea')?.focus(), 250)
   }
 }
 
@@ -1050,15 +1047,6 @@ watch(() => props.initialIndex, idx => {
   z-index: 10;
 }
 
-/* Wrapper: Desktop flex-row (left-group neben Stars), Mobile als eigene Zeile */
-.sr-loupe__left-group {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  flex: 1;
-  min-width: 0;
-}
-
 .sr-loupe__footer-left {
   display: flex;
   flex-direction: column;
@@ -1083,8 +1071,9 @@ watch(() => props.initialIndex, idx => {
 .sr-loupe__footer-center {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 12px;
-  flex-shrink: 0;
+  flex: 1;
 }
 
 .sr-loupe__footer-right {
@@ -1174,35 +1163,6 @@ watch(() => props.initialIndex, idx => {
   }
 }
 
-/* ── Mobile: zweizeiliger Footer + Android-Navigationsleiste ─────────────── */
-@media (pointer: coarse) {
-  .sr-loupe__footer {
-    padding-bottom: max(72px, env(safe-area-inset-bottom));
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 6px 12px;
-  }
-  /* Zeile 1: Steuerelemente */
-  .sr-loupe__footer-center { order: 1; }
-  .sr-loupe__footer-right  { order: 1; }
-  /* Zeile 2: left-group (Dateiname/Index + Kommentar-Button), volle Breite, zentriert */
-  .sr-loupe__left-group {
-    order: 2;
-    flex: 0 0 100%;
-    justify-content: center;
-    align-items: center;
-  }
-  .sr-loupe__footer-left {
-    flex: 0 1 auto;
-    align-items: center;
-    text-align: center;
-  }
-  .sr-loupe__comment-btn {
-    align-self: center;
-    padding: 4px 8px;
-  }
-}
-
 /* ── Kommentar-Button ──────────────────────────────────────────────────────── */
 
 .sr-loupe__comment-btn {
@@ -1214,12 +1174,54 @@ watch(() => props.initialIndex, idx => {
   display: flex;
   align-items: center;
   justify-content: center;
-  align-self: stretch;   /* volle Höhe von footer-left, Icon mittig */
+  gap: 6px;
+  align-self: center;
   flex-shrink: 0;
   transition: color 0.15s;
 }
+.sr-loupe__comment-icon { width: 16px; height: 16px; }
+.sr-loupe__comment-label {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
 .sr-loupe__comment-btn--active { color: #e94560; }
 .sr-loupe__comment-btn:hover   { color: #d4d4d8; }
+
+/* ── Mobile: zweizeiliger Footer + Android-Navigationsleiste ─────────────── */
+@media (pointer: coarse) {
+  .sr-loupe__footer {
+    padding-bottom: max(72px, env(safe-area-inset-bottom));
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px 12px;
+  }
+  /* Zeile 1: Steuerelemente */
+  .sr-loupe__footer-center { order: 1; flex: 0 0 auto; justify-content: center; }
+  .sr-loupe__footer-right  { order: 1; }
+  /* Zeilenumbruch zwischen Zeile 1 und 2 */
+  .sr-loupe__footer::after {
+    content: '';
+    order: 1;
+    flex-basis: 100%;
+    height: 0;
+  }
+  /* Zeile 2: Dateiname + Kommentar-Button, zentriert */
+  .sr-loupe__footer-left {
+    order: 2;
+    flex: 0 1 auto;
+    align-items: center;
+    text-align: center;
+  }
+  .sr-loupe__comment-btn {
+    order: 2;
+    align-self: center;
+    padding: 8px 16px;
+    margin: 0 0 0 14px;
+  }
+  .sr-loupe__comment-icon { width: 26px; height: 26px; }
+  .sr-loupe__comment-label { display: none; }
+}
 
 /* ── Kommentar Bottom Sheet ────────────────────────────────────────────────── */
 
@@ -1230,6 +1232,16 @@ watch(() => props.initialIndex, idx => {
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  transform: translateY(100%);
+  opacity: 0;
+  pointer-events: none;
+  will-change: transform, opacity;
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+}
+.sr-loupe__comment-sheet-overlay--open {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .sr-loupe__comment-sheet {
@@ -1345,9 +1357,4 @@ watch(() => props.initialIndex, idx => {
 .sr-loupe__comment-status--ok    { color: #7ecf7e; }
 .sr-loupe__comment-status--error { color: #e94560; }
 
-/* Slide-up Transition */
-.sr-comment-sheet-enter-active,
-.sr-comment-sheet-leave-active { transition: transform 0.25s ease; }
-.sr-comment-sheet-enter-from,
-.sr-comment-sheet-leave-to { transform: translateY(100%); }
 </style>

--- a/src/views/GuestGallery.vue
+++ b/src/views/GuestGallery.vue
@@ -153,7 +153,7 @@ const commentApi = {
     const url = generateUrl(`/apps/starrate/api/guest/${props.token}/comment/${fileId}`)
     try {
       const { data } = await axios.get(url, { headers: pwHeader() })
-      return data.comment ?? null
+      return data ?? null
     } catch {
       return null
     }

--- a/tests/Unit/Controller/RatingControllerTest.php
+++ b/tests/Unit/Controller/RatingControllerTest.php
@@ -6,7 +6,9 @@ namespace OCA\StarRate\Tests\Unit\Controller;
 
 use OCA\StarRate\Controller\RatingController;
 use OCA\StarRate\Service\ExifService;
+use OCA\StarRate\Service\ShareService;
 use OCA\StarRate\Service\TagService;
+use OCA\StarRate\Settings\UserSettings;
 use OCP\AppFramework\Http;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -32,6 +34,10 @@ class RatingControllerTest extends TestCase
     private TagService $tagService;
     /** @var ExifService&MockObject */
     private ExifService $exifService;
+    /** @var UserSettings&MockObject */
+    private UserSettings $userSettings;
+    /** @var ShareService&MockObject */
+    private ShareService $shareService;
     /** @var LoggerInterface&MockObject */
     private LoggerInterface $logger;
 
@@ -40,16 +46,24 @@ class RatingControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->request     = $this->createMock(IRequest::class);
-        $this->rootFolder  = $this->createMock(IRootFolder::class);
-        $this->userSession = $this->createMock(IUserSession::class);
-        $this->tagService  = $this->createMock(TagService::class);
-        $this->exifService = $this->createMock(ExifService::class);
-        $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->request      = $this->createMock(IRequest::class);
+        $this->rootFolder   = $this->createMock(IRootFolder::class);
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->tagService   = $this->createMock(TagService::class);
+        $this->exifService  = $this->createMock(ExifService::class);
+        $this->userSettings = $this->createMock(UserSettings::class);
+        $this->shareService = $this->createMock(ShareService::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
 
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn(self::USER_ID);
         $this->userSession->method('getUser')->willReturn($user);
+
+        // Default: write_xmp aktiv, comments_enabled aktiv
+        $this->userSettings->method('getSettings')->willReturn([
+            'write_xmp'        => true,
+            'comments_enabled' => true,
+        ]);
 
         $this->controller = new RatingController(
             'starrate',
@@ -58,6 +72,8 @@ class RatingControllerTest extends TestCase
             $this->userSession,
             $this->tagService,
             $this->exifService,
+            $this->userSettings,
+            $this->shareService,
             $this->logger,
         );
     }
@@ -379,6 +395,126 @@ class RatingControllerTest extends TestCase
         $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
     }
 
+    // ─── Tests: Kommentare (Owner) ──────────────────────────────────────────
+
+    public function testGetCommentReturnsData(): void
+    {
+        $this->shareService->method('getComment')
+            ->with(self::FILE_ID)
+            ->willReturn([
+                'file_id'     => self::FILE_ID,
+                'comment'     => 'Tolles Licht!',
+                'author_type' => 'owner',
+                'author_name' => self::USER_ID,
+                'updated_at'  => 1713000000,
+            ]);
+
+        $response = $this->controller->getComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('Tolles Licht!', $response->getData()['comment']);
+        $this->assertSame(self::USER_ID, $response->getData()['author_name']);
+        $this->assertSame(1713000000, $response->getData()['updated_at']);
+    }
+
+    public function testGetCommentReturnsNullWhenEmpty(): void
+    {
+        $this->shareService->method('getComment')->willReturn(null);
+
+        $response = $this->controller->getComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertNull($response->getData()['comment']);
+    }
+
+    public function testGetCommentReturns403WhenDisabled(): void
+    {
+        $this->userSettings = $this->createMock(UserSettings::class);
+        $this->userSettings->method('getSettings')->willReturn([
+            'write_xmp'        => true,
+            'comments_enabled' => false,
+        ]);
+
+        $controller = new RatingController(
+            'starrate', $this->request, $this->rootFolder,
+            $this->userSession, $this->tagService, $this->exifService,
+            $this->userSettings, $this->shareService, $this->logger,
+        );
+
+        $response = $controller->getComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }
+
+    public function testSaveCommentCallsService(): void
+    {
+        $this->mockJsonBody(['comment' => 'Schönes Bild']);
+        $this->shareService->expects($this->once())
+            ->method('saveComment')
+            ->with(self::FILE_ID, 'Schönes Bild', 'owner', self::USER_ID)
+            ->willReturn([
+                'file_id' => self::FILE_ID, 'comment' => 'Schönes Bild',
+                'author_type' => 'owner', 'author_name' => self::USER_ID, 'updated_at' => time(),
+            ]);
+
+        $response = $this->controller->saveComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('Schönes Bild', $response->getData()['comment']);
+    }
+
+    public function testSaveCommentReturns422WhenEmpty(): void
+    {
+        $this->mockJsonBody(['comment' => '   ']);
+
+        $response = $this->controller->saveComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+    }
+
+    public function testSaveCommentReturns403WhenDisabled(): void
+    {
+        $this->userSettings = $this->createMock(UserSettings::class);
+        $this->userSettings->method('getSettings')->willReturn([
+            'write_xmp'        => true,
+            'comments_enabled' => false,
+        ]);
+
+        $controller = new RatingController(
+            'starrate', $this->request, $this->rootFolder,
+            $this->userSession, $this->tagService, $this->exifService,
+            $this->userSettings, $this->shareService, $this->logger,
+        );
+
+        $this->mockJsonBody(['comment' => 'Test']);
+        $response = $controller->saveComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }
+
+    public function testDeleteCommentCallsService(): void
+    {
+        $this->shareService->expects($this->once())
+            ->method('deleteComment')
+            ->with(self::FILE_ID);
+
+        $response = $this->controller->deleteComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertTrue($response->getData()['ok']);
+    }
+
+    public function testDeleteCommentReturns403WhenDisabled(): void
+    {
+        $this->userSettings = $this->createMock(UserSettings::class);
+        $this->userSettings->method('getSettings')->willReturn([
+            'write_xmp'        => true,
+            'comments_enabled' => false,
+        ]);
+
+        $controller = new RatingController(
+            'starrate', $this->request, $this->rootFolder,
+            $this->userSession, $this->tagService, $this->exifService,
+            $this->userSettings, $this->shareService, $this->logger,
+        );
+
+        $response = $controller->deleteComment(self::FILE_ID);
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }
+
     // ─── Tests: Nicht authentifiziert ────────────────────────────────────────
 
     public function testGetReturns401WhenNotAuthenticated(): void
@@ -389,6 +525,7 @@ class RatingControllerTest extends TestCase
         $controller = new RatingController(
             'starrate', $this->request, $this->rootFolder,
             $this->userSession, $this->tagService, $this->exifService,
+            $this->userSettings, $this->shareService,
             $this->createMock(LoggerInterface::class),
         );
 

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -10,6 +10,7 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IPreview as IPreviewManager;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -26,6 +27,8 @@ class ShareServiceTest extends TestCase
     private ISecureRandom $secureRandom;
     /** @var IRootFolder&MockObject */
     private IRootFolder $rootFolder;
+    /** @var IDBConnection&MockObject */
+    private IDBConnection $db;
 
     private const OWNER_ID     = 'photographer1';
     private const SAMPLE_TOKEN = 'AbCdEfGh12345678AbCdEfGh';
@@ -35,6 +38,7 @@ class ShareServiceTest extends TestCase
         $this->config       = $this->createMock(IConfig::class);
         $this->rootFolder   = $this->createMock(IRootFolder::class);
         $this->secureRandom = $this->createMock(ISecureRandom::class);
+        $this->db           = $this->createMock(IDBConnection::class);
 
         // Default: getUserFolder returns a Folder that finds nothing
         $emptyFolder = $this->createMock(Folder::class);
@@ -48,6 +52,7 @@ class ShareServiceTest extends TestCase
             $this->secureRandom,
             $this->createMock(TagService::class),
             $this->createMock(LoggerInterface::class),
+            $this->db,
         );
     }
 
@@ -333,6 +338,174 @@ class ShareServiceTest extends TestCase
     {
         // getGuestLog requires getShare() which uses \OC::$server DB — skip
         $this->markTestSkipped('getGuestLog() calls getShare() which requires \OC::$server — integration test only.');
+    }
+
+    // ─── Tests: getSharesByOwner ──────────────────────────────────────────────
+
+    // ─── Tests: Kommentare ──────────────────────────────────────────────────
+
+    public function testSaveCommentInsertsNew(): void
+    {
+        // Mock: UPDATE betrifft 0 Zeilen → INSERT
+        $qbUpdate = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+        $qbUpdate->method('update')->willReturnSelf();
+        $qbUpdate->method('set')->willReturnSelf();
+        $qbUpdate->method('where')->willReturnSelf();
+        $qbUpdate->method('createNamedParameter')->willReturnSelf();
+        $qbUpdate->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+        $qbUpdate->method('executeStatement')->willReturn(0);
+
+        $qbInsert = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+        $qbInsert->method('insert')->willReturnSelf();
+        $qbInsert->method('values')->willReturnSelf();
+        $qbInsert->method('createNamedParameter')->willReturnSelf();
+        $qbInsert->method('executeStatement')->willReturn(1);
+
+        $this->db->expects($this->exactly(2))
+            ->method('getQueryBuilder')
+            ->willReturnOnConsecutiveCalls($qbUpdate, $qbInsert);
+
+        $result = $this->service->saveComment(42, 'Tolles Bild!', 'owner', 'photographer1');
+
+        $this->assertSame(42, $result['file_id']);
+        $this->assertSame('Tolles Bild!', $result['comment']);
+        $this->assertSame('owner', $result['author_type']);
+        $this->assertSame('photographer1', $result['author_name']);
+        $this->assertGreaterThan(0, $result['updated_at']);
+    }
+
+    public function testSaveCommentUpdatesExisting(): void
+    {
+        // Mock: UPDATE betrifft 1 Zeile → kein INSERT
+        $qbUpdate = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+        $qbUpdate->method('update')->willReturnSelf();
+        $qbUpdate->method('set')->willReturnSelf();
+        $qbUpdate->method('where')->willReturnSelf();
+        $qbUpdate->method('createNamedParameter')->willReturnSelf();
+        $qbUpdate->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+        $qbUpdate->method('executeStatement')->willReturn(1);
+
+        $this->db->expects($this->once())
+            ->method('getQueryBuilder')
+            ->willReturn($qbUpdate);
+
+        $result = $this->service->saveComment(42, 'Update!', 'guest', 'Anna');
+
+        $this->assertSame('Update!', $result['comment']);
+        $this->assertSame('guest', $result['author_type']);
+        $this->assertSame('Anna', $result['author_name']);
+    }
+
+    public function testSaveCommentTruncatesTo2000Chars(): void
+    {
+        $qbUpdate = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+        $qbUpdate->method('update')->willReturnSelf();
+        $qbUpdate->method('set')->willReturnSelf();
+        $qbUpdate->method('where')->willReturnSelf();
+        $qbUpdate->method('createNamedParameter')->willReturnSelf();
+        $qbUpdate->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+        $qbUpdate->method('executeStatement')->willReturn(1);
+
+        $this->db->method('getQueryBuilder')->willReturn($qbUpdate);
+
+        $longText = str_repeat('x', 3000);
+        $result = $this->service->saveComment(42, $longText, 'owner', 'user1');
+
+        $this->assertSame(2000, mb_strlen($result['comment']));
+    }
+
+    public function testGetCommentReturnsNullWhenNotFound(): void
+    {
+        $qb = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('createNamedParameter')->willReturnSelf();
+        $qb->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+
+        $queryResult = $this->createMock(\OCP\DB\IResult::class);
+        $queryResult->method('fetch')->willReturn(false);
+        $qb->method('executeQuery')->willReturn($queryResult);
+
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+
+        $this->assertNull($this->service->getComment(999));
+    }
+
+    public function testGetCommentReturnsData(): void
+    {
+        $qb = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('createNamedParameter')->willReturnSelf();
+        $qb->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+
+        $queryResult = $this->createMock(\OCP\DB\IResult::class);
+        $queryResult->method('fetch')->willReturn([
+            'file_id'     => '42',
+            'comment'     => 'Super Foto',
+            'author_type' => 'guest',
+            'author_name' => 'Anna',
+            'updated_at'  => '1713000000',
+        ]);
+        $qb->method('executeQuery')->willReturn($queryResult);
+
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+
+        $result = $this->service->getComment(42);
+        $this->assertSame(42, $result['file_id']);
+        $this->assertSame('Super Foto', $result['comment']);
+        $this->assertSame('guest', $result['author_type']);
+        $this->assertSame('Anna', $result['author_name']);
+        $this->assertSame(1713000000, $result['updated_at']);
+    }
+
+    public function testDeleteCommentExecutesDelete(): void
+    {
+        $qb = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+        $qb->method('delete')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('createNamedParameter')->willReturnSelf();
+        $qb->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+        $qb->expects($this->once())->method('executeStatement');
+
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+
+        $this->service->deleteComment(42);
+    }
+
+    // ─── Tests: Guest-Log-Trimming ────────────────────────────────────────────
+
+    public function testGuestLogTrimmedTo500Entries(): void
+    {
+        $share = ['token' => self::SAMPLE_TOKEN, 'owner_id' => self::OWNER_ID];
+
+        // Bestehendes Log mit 499 Einträgen
+        $existingLog = [];
+        for ($i = 0; $i < 499; $i++) {
+            $existingLog[] = ['file_id' => $i, 'rating' => 1, 'color' => null, 'pick' => null, 'guest_name' => 'Bot', 'timestamp' => $i + 1];
+        }
+
+        $saved = null;
+        $this->config->method('getUserValue')->willReturn(json_encode($existingLog));
+        $this->config->method('setUserValue')
+            ->willReturnCallback(function ($u, $a, $k, $v) use (&$saved) { $saved = json_decode($v, true); });
+
+        // Eintrag 500 → genau am Limit
+        $this->service->saveGuestRating($share, 500, 5, null, null, 'Anna');
+        $this->assertCount(500, $saved);
+
+        // Eintrag 501 → wird getrimmt
+        $saved = null;
+        $existingLog500 = $existingLog;
+        $existingLog500[] = ['file_id' => 500, 'rating' => 5, 'color' => null, 'pick' => null, 'guest_name' => 'Anna', 'timestamp' => 500];
+        $this->config->method('getUserValue')->willReturn(json_encode($existingLog500));
+
+        $this->service->saveGuestRating($share, 501, 3, null, null, 'Bob');
+        $this->assertCount(500, $saved);
+        // Ältester Eintrag (file_id=0) sollte raus sein
+        $this->assertNotSame(0, $saved[0]['file_id']);
     }
 
     // ─── Tests: getSharesByOwner ──────────────────────────────────────────────

--- a/tests/e2e/comments.cy.js
+++ b/tests/e2e/comments.cy.js
@@ -1,0 +1,150 @@
+/**
+ * StarRate E2E – Kommentare: Owner + Gast
+ */
+
+import { NC_URL, NC_USER, NC_PASS, APP_URL, TEST_FOLDER, login, openFolder, createShare, deleteShare } from './helpers'
+
+describe('Kommentare', () => {
+
+  // ── Hilfsfunktion: Settings-API aufrufen ─────────────────────────────────
+
+  function setCommentsEnabled(enabled) {
+    cy.request({
+      method: 'POST',
+      url: `${NC_URL}/index.php/apps/starrate/api/settings`,
+      body: { comments_enabled: enabled },
+      headers: { 'Content-Type': 'application/json', 'OCS-APIREQUEST': 'true' },
+      auth: { user: NC_USER, pass: NC_PASS },
+    })
+  }
+
+  function deleteCommentApi(fileId) {
+    cy.request({
+      method: 'DELETE',
+      url: `${NC_URL}/index.php/apps/starrate/api/rating/${fileId}/comment`,
+      headers: { 'OCS-APIREQUEST': 'true' },
+      auth: { user: NC_USER, pass: NC_PASS },
+      failOnStatusCode: false,
+    })
+  }
+
+  // ── Owner-Kommentare ────────────────────────────────────────────────────
+
+  describe('Owner', () => {
+
+    before(() => {
+      login()
+      setCommentsEnabled(true)
+    })
+
+    it('zeigt Kommentar-Button in der Loupe', () => {
+      login()
+      openFolder()
+      // Erstes Bild in die Loupe öffnen
+      cy.get('.sr-grid__item:not(.sr-grid__item--skeleton)').first().dblclick()
+      cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+      cy.get('.sr-loupe__comment-btn').should('be.visible')
+    })
+
+    it('erstellt, bearbeitet und löscht einen Kommentar', () => {
+      login()
+      openFolder()
+      cy.get('.sr-grid__item:not(.sr-grid__item--skeleton)').first().dblclick()
+      cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+
+      // Neuen Kommentar erstellen
+      cy.get('.sr-loupe__comment-btn').click()
+      cy.get('.sr-loupe__comment-textarea', { timeout: 3000 }).should('be.visible')
+      cy.get('.sr-loupe__comment-textarea').type('E2E Testkommentar')
+      cy.get('.sr-loupe__comment-btn-save').click()
+
+      // View-Modus: Kommentar sichtbar
+      cy.get('.sr-loupe__comment-text', { timeout: 5000 }).should('contain', 'E2E Testkommentar')
+      cy.get('.sr-loupe__comment-btn--active').should('exist')
+
+      // Bearbeiten
+      cy.get('.sr-loupe__comment-action').first().click() // Edit-Button
+      cy.get('.sr-loupe__comment-textarea').clear().type('Bearbeitet')
+      cy.get('.sr-loupe__comment-btn-save').click()
+      cy.get('.sr-loupe__comment-text', { timeout: 5000 }).should('contain', 'Bearbeitet')
+
+      // Löschen
+      cy.get('.sr-loupe__comment-action--delete').click()
+      cy.get('.sr-loupe__comment-btn-save--danger').click()
+
+      // Sheet geschlossen, Button nicht mehr aktiv
+      cy.get('.sr-loupe__comment-sheet-overlay--open').should('not.exist')
+      cy.get('.sr-loupe__comment-btn--active').should('not.exist')
+    })
+
+    it('versteckt Kommentar-Button wenn comments_enabled=false', () => {
+      login()
+      setCommentsEnabled(false)
+      openFolder()
+      cy.get('.sr-grid__item:not(.sr-grid__item--skeleton)').first().dblclick()
+      cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+      cy.get('.sr-loupe__comment-btn').should('not.exist')
+
+      // Cleanup: wieder aktivieren
+      setCommentsEnabled(true)
+    })
+  })
+
+  // ── Gast-Kommentare ─────────────────────────────────────────────────────
+
+  describe('Gast', () => {
+    let token
+
+    before(() => {
+      login()
+      setCommentsEnabled(true)
+      createShare({
+        permissions: 'rate',
+        guest_name: 'Kommentar-Gast',
+        allow_comment: true,
+      }).then(share => {
+        token = share.token
+      })
+    })
+
+    after(() => deleteShare(token))
+
+    it('Gast sieht Kommentar-Button und kann kommentieren', () => {
+      cy.clearCookies()
+      cy.visit(`${NC_URL}/index.php/apps/starrate/guest/${token}`)
+      cy.get('.sr-grid__item:not(.sr-grid__item--skeleton)', { timeout: 15000 })
+        .should('have.length.greaterThan', 0)
+
+      // Erstes Bild in Loupe öffnen
+      cy.get('.sr-grid__item:not(.sr-grid__item--skeleton)').first().dblclick()
+      cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+      cy.get('.sr-loupe__comment-btn').should('be.visible')
+
+      // Kommentar schreiben
+      cy.get('.sr-loupe__comment-btn').click()
+      cy.get('.sr-loupe__comment-textarea', { timeout: 3000 }).should('be.visible')
+      cy.get('.sr-loupe__comment-textarea').type('Gast-Kommentar E2E')
+      cy.get('.sr-loupe__comment-btn-save').click()
+      cy.get('.sr-loupe__comment-text', { timeout: 5000 }).should('contain', 'Gast-Kommentar E2E')
+      cy.get('.sr-loupe__comment-meta').should('contain', 'Kommentar-Gast')
+    })
+
+    it('Gast ohne allow_comment sieht keinen Button', () => {
+      login()
+      createShare({
+        permissions: 'rate',
+        guest_name: 'Kein-Kommentar',
+        allow_comment: false,
+      }).then(share => {
+        cy.clearCookies()
+        cy.visit(`${NC_URL}/index.php/apps/starrate/guest/${share.token}`)
+        cy.get('.sr-grid__item:not(.sr-grid__item--skeleton)', { timeout: 15000 })
+          .should('have.length.greaterThan', 0)
+        cy.get('.sr-grid__item:not(.sr-grid__item--skeleton)').first().dblclick()
+        cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+        cy.get('.sr-loupe__comment-btn').should('not.exist')
+        deleteShare(share.token)
+      })
+    })
+  })
+})

--- a/tests/js/GuestGallery.spec.js
+++ b/tests/js/GuestGallery.spec.js
@@ -9,13 +9,17 @@ import GuestGallery from '../../src/views/GuestGallery.vue'
 const GalleryStub = defineComponent({
   name: 'Gallery',
   props: {
-    guestMode:      { type: Boolean, default: false },
-    guestLabel:     { type: String,  default: '' },
-    loadImagesFn:   { type: Function, default: null },
-    rateFn:         { type: Function, default: null },
-    batchRateFn:    { type: Function, default: null },
-    thumbnailUrlFn: { type: Function, default: null },
-    previewUrlFn:   { type: Function, default: null },
+    guestMode:       { type: Boolean, default: false },
+    guestLabel:      { type: String,  default: '' },
+    enablePickOverride: { type: Boolean, default: false },
+    allowExport:     { type: Boolean, default: false },
+    allowComment:    { type: Boolean, default: false },
+    commentApi:      { type: Object, default: null },
+    loadImagesFn:    { type: Function, default: null },
+    rateFn:          { type: Function, default: null },
+    batchRateFn:     { type: Function, default: null },
+    thumbnailUrlFn:  { type: Function, default: null },
+    previewUrlFn:    { type: Function, default: null },
   },
   template: '<div class="gallery-stub" />',
 })
@@ -241,5 +245,73 @@ describe('GuestGallery', () => {
     const w = factory()
     const url = galleryProps(w).previewUrlFn(55)
     expect(url).toContain('/guest/tok123/preview/55')
+  })
+
+  // ── commentApi ──────────────────────────────────────────────────────────────
+
+  it('übergibt allowComment=true und commentApi wenn allowComment-Prop gesetzt', () => {
+    const w = factory({ allowComment: true })
+    const p = galleryProps(w)
+    expect(p.allowComment).toBe(true)
+    expect(p.commentApi).toBeTruthy()
+    expect(typeof p.commentApi.save).toBe('function')
+    expect(typeof p.commentApi.load).toBe('function')
+    expect(typeof p.commentApi.remove).toBe('function')
+  })
+
+  it('übergibt allowComment=false wenn nicht gesetzt', () => {
+    const w = factory()
+    const p = galleryProps(w)
+    expect(p.allowComment).toBe(false)
+  })
+
+  it('commentApi.save sendet korrekte Daten', async () => {
+    axios.post.mockResolvedValue({ data: { comment: 'Hallo', author_name: 'Gast', updated_at: 1713000000 } })
+    const w = factory({ allowComment: true })
+    const { commentApi } = galleryProps(w)
+
+    const result = await commentApi.save(42, 'Hallo', 'Testgast')
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/guest/tok123/comment'),
+      expect.objectContaining({ file_id: 42, comment: 'Hallo', guest_name: 'Testgast' }),
+      expect.any(Object)
+    )
+    expect(result.comment).toBe('Hallo')
+  })
+
+  it('commentApi.load ruft GET-Endpunkt auf', async () => {
+    axios.get.mockResolvedValue({ data: { comment: 'Toll', author_name: 'Anna', updated_at: 1713000000 } })
+    const w = factory({ allowComment: true })
+    const { commentApi } = galleryProps(w)
+
+    const result = await commentApi.load(42)
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining('/guest/tok123/comment/42'),
+      expect.any(Object)
+    )
+    expect(result.comment).toBe('Toll')
+    expect(result.author_name).toBe('Anna')
+    expect(result.updated_at).toBe(1713000000)
+  })
+
+  it('commentApi.load gibt null zurück bei Fehler', async () => {
+    axios.get.mockRejectedValue(new Error('Network error'))
+    const w = factory({ allowComment: true })
+    const { commentApi } = galleryProps(w)
+
+    const result = await commentApi.load(42)
+    expect(result).toBeNull()
+  })
+
+  it('commentApi.remove ruft DELETE-Endpunkt auf', async () => {
+    axios.delete.mockResolvedValue({ data: {} })
+    const w = factory({ allowComment: true })
+    const { commentApi } = galleryProps(w)
+
+    await commentApi.remove(42)
+    expect(axios.delete).toHaveBeenCalledWith(
+      expect.stringContaining('/guest/tok123/comment/42'),
+      expect.any(Object)
+    )
   })
 })

--- a/tests/js/ZoomView.spec.js
+++ b/tests/js/ZoomView.spec.js
@@ -17,6 +17,170 @@ const factory = (props = {}) => mount(LoupeView, {
   attachTo: document.body,
 })
 
+describe('LoupeView – Kommentare', () => {
+
+  it('zeigt Kommentar-Button wenn commentsEnabledOwner=true', () => {
+    const w = factory({ commentsEnabledOwner: true })
+    expect(w.find('.sr-loupe__comment-btn').exists()).toBe(true)
+  })
+
+  it('zeigt Kommentar-Button wenn allowComment=true', () => {
+    const w = factory({ allowComment: true })
+    expect(w.find('.sr-loupe__comment-btn').exists()).toBe(true)
+  })
+
+  it('versteckt Kommentar-Button wenn weder allowComment noch commentsEnabledOwner', () => {
+    const w = factory()
+    expect(w.find('.sr-loupe__comment-btn').exists()).toBe(false)
+  })
+
+  it('Kommentar-Sheet ist initial geschlossen', () => {
+    const w = factory({ commentsEnabledOwner: true })
+    expect(w.find('.sr-loupe__comment-sheet-overlay--open').exists()).toBe(false)
+  })
+
+  it('öffnet Kommentar-Sheet bei Klick auf Button', async () => {
+    const w = factory({ commentsEnabledOwner: true })
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    expect(w.find('.sr-loupe__comment-sheet-overlay--open').exists()).toBe(true)
+  })
+
+  it('schließt Kommentar-Sheet bei Klick auf ✕', async () => {
+    const w = factory({ commentsEnabledOwner: true })
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    expect(w.find('.sr-loupe__comment-sheet-overlay--open').exists()).toBe(true)
+    await w.find('.sr-loupe__comment-close').trigger('click')
+    expect(w.find('.sr-loupe__comment-sheet-overlay--open').exists()).toBe(false)
+  })
+
+  it('schließt Kommentar-Sheet bei Escape', async () => {
+    const w = factory({ commentsEnabledOwner: true })
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    expect(w.find('.sr-loupe__comment-sheet-overlay--open').exists()).toBe(true)
+    await w.find('.sr-loupe').trigger('keydown', { key: 'Escape' })
+    expect(w.find('.sr-loupe__comment-sheet-overlay--open').exists()).toBe(false)
+  })
+
+  it('zeigt Textarea im neuen Kommentar-Modus', async () => {
+    const w = factory({ commentsEnabledOwner: true })
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    expect(w.find('.sr-loupe__comment-textarea').exists()).toBe(true)
+  })
+
+  it('Button hat Akzentfarbe wenn Kommentar vorhanden (via commentApi)', async () => {
+    const commentApi = {
+      load: vi.fn().mockResolvedValue({ comment: 'Toll', author_name: 'Anna', updated_at: 1713000000 }),
+      save: vi.fn(),
+      remove: vi.fn(),
+    }
+    const w = factory({ allowComment: true, commentApi })
+    await flushPromises()
+    expect(w.find('.sr-loupe__comment-btn--active').exists()).toBe(true)
+  })
+
+  it('Button hat keine Akzentfarbe ohne Kommentar', async () => {
+    const commentApi = {
+      load: vi.fn().mockResolvedValue(null),
+      save: vi.fn(),
+      remove: vi.fn(),
+    }
+    const w = factory({ allowComment: true, commentApi })
+    await flushPromises()
+    expect(w.find('.sr-loupe__comment-btn--active').exists()).toBe(false)
+  })
+
+  it('loadComment gibt Autor und Datum aus API zurück', async () => {
+    const commentApi = {
+      load: vi.fn().mockResolvedValue({ comment: 'Super!', author_name: 'Max', updated_at: 1713050000 }),
+      save: vi.fn(),
+      remove: vi.fn(),
+    }
+    const w = factory({ allowComment: true, commentApi })
+    await flushPromises()
+    // Sheet öffnen
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    // View-Modus — zeigt Autor und Text
+    expect(w.find('.sr-loupe__comment-meta').text()).toContain('Max')
+    expect(w.find('.sr-loupe__comment-text').text()).toContain('Super!')
+  })
+
+  it('speichert Kommentar über commentApi', async () => {
+    const commentApi = {
+      load: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue({ comment: 'Neuer Text', author_name: 'Ich', updated_at: 1713060000 }),
+      remove: vi.fn(),
+    }
+    const w = factory({ allowComment: true, commentApi })
+    await flushPromises()
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    await w.find('.sr-loupe__comment-textarea').setValue('Neuer Text')
+    await w.find('.sr-loupe__comment-btn-save').trigger('click')
+    await flushPromises()
+    expect(commentApi.save).toHaveBeenCalledWith(1, 'Neuer Text')
+    // Wechselt in View-Modus
+    expect(w.find('.sr-loupe__comment-text').text()).toContain('Neuer Text')
+  })
+
+  it('Speichern-Button ist disabled bei leerem Text', async () => {
+    const commentApi = {
+      load: vi.fn().mockResolvedValue(null),
+      save: vi.fn(),
+      remove: vi.fn(),
+    }
+    const w = factory({ allowComment: true, commentApi })
+    await flushPromises()
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    expect(w.find('.sr-loupe__comment-btn-save').attributes('disabled')).toBeDefined()
+  })
+
+  it('zeigt Lösch-Bestätigung und löscht bei Klick auf Ja', async () => {
+    const commentApi = {
+      load: vi.fn().mockResolvedValue({ comment: 'Alte Notiz', author_name: 'Anna', updated_at: 1713000000 }),
+      save: vi.fn(),
+      remove: vi.fn().mockResolvedValue(undefined),
+    }
+    const w = factory({ allowComment: true, commentApi })
+    await flushPromises()
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    // View-Modus → Löschen-Button
+    await w.find('.sr-loupe__comment-action--delete').trigger('click')
+    // Bestätigungsdialog
+    expect(w.find('.sr-loupe__comment-btn-save--danger').exists()).toBe(true)
+    await w.find('.sr-loupe__comment-btn-save--danger').trigger('click')
+    await flushPromises()
+    expect(commentApi.remove).toHaveBeenCalledWith(1)
+    // Sheet geschlossen, Button nicht mehr aktiv
+    expect(w.find('.sr-loupe__comment-sheet-overlay--open').exists()).toBe(false)
+    expect(w.find('.sr-loupe__comment-btn--active').exists()).toBe(false)
+  })
+
+  it('Abbrechen in Lösch-Bestätigung kehrt zur View zurück', async () => {
+    const commentApi = {
+      load: vi.fn().mockResolvedValue({ comment: 'Notiz', author_name: 'Anna', updated_at: 1713000000 }),
+      save: vi.fn(),
+      remove: vi.fn(),
+    }
+    const w = factory({ allowComment: true, commentApi })
+    await flushPromises()
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    await w.find('.sr-loupe__comment-action--delete').trigger('click')
+    await w.find('.sr-loupe__comment-btn-cancel').trigger('click')
+    // Zurück in View-Modus — Kommentartext noch da
+    expect(w.find('.sr-loupe__comment-text').text()).toContain('Notiz')
+    expect(w.find('.sr-loupe__comment-btn-save--danger').exists()).toBe(false)
+  })
+
+})
+
 describe('LoupeView – Zoom & Navigation', () => {
 
   // ── Grundrendering ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #4 — Kommentar-Funktion für Fotos (Owner + Gast).

### Features
- **Kommentar pro Foto** (global, nicht per Share) mit UPSERT-Logik
- **Owner-Kommentare**: `comments_enabled` Setting als Master-Switch
- **Gast-Kommentare**: `allow_comment` pro Share, Gast-Log-Eintrag
- **LoupeView UI**: Bottom-Sheet mit States (new/view/edit/confirm-delete), CSS-only Transition
- **Desktop**: Icon + "Kommentar" Label zentriert zwischen Filename und Bewertung
- **Mobile**: Icon-only Button (26px), Label hidden

### Backend
- DB-Migration: `starrate_comments` Tabelle (file_id UNIQUE)
- ShareService: saveComment (UPSERT), getComment, deleteComment, appendCommentToLog
- RatingController: Owner-Endpunkte (GET/POST/DELETE `/api/rating/{fileId}/comment`)
- ShareController: Gast-Endpunkte mit `allow_comment` + `fileExistsInShare` Check
- Guest-Log-Trimming auf 500 Einträge

### Frontend
- LoupeView: Comment-Sheet State Machine, Autor/Datum-Anzeige, Lösch-Bestätigung
- GuestGallery: commentApi Callbacks (save/load/remove)
- ShareModal: "Kommentare erlauben" Toggle
- SettingsPanel: "Kommentare aktivieren" Master-Switch
- i18n: DE + EN Strings

### Bugfixes (UI-Iteration)
- Flicker-Fix: CSS-only Transition statt Vue `<Transition>`, Focus-Delay 250ms
- Author-Bug: `data.comment` → `data` in Owner + Guest Pfaden
- CSS-Specificity: Base-Rules vor `@media (pointer: coarse)` Overrides

### Tests
- **PHPUnit**: ShareService (save/get/delete Comment, Truncation, Log-Trimming), RatingController (Comment-Endpunkte, comments_enabled Gate)
- **Vitest**: LoupeView Comment-Sheet (State Machine, Button, Autor/Datum, Lösch-Flow), GuestGallery commentApi (save/load/remove)
- **Cypress E2E**: Owner + Gast Kommentar-Lifecycle, Settings-Toggle

## Test plan
- [x] Desktop: Comment button centered with icon + label
- [x] Mobile: Icon-only, adequate size
- [x] Smooth open/close animation (no flicker)
- [x] Author + date displayed after reload
- [x] Save, edit, delete comment flows
- [x] Guest share comment with allow_comment
- [x] comments_enabled=false hides button
- [x] Vitest: 325 tests passing
- [x] PHPUnit: Comment tests added
- [x] Cypress: Comment E2E tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)