### PR TITLE
fix: defer neighbor preload until full preview is ready

### DIFF
--- a/css/starrate-guest.css
+++ b/css/starrate-guest.css
@@ -1,3 +1,3 @@
 /* extracted by css-entry-points-plugin */
 @import './guest-bR0Rjup5.chunk.css';
-@import './Gallery-D2_t6yGf.chunk.css';
+@import './Gallery-kXsJ-YGE.chunk.css';

--- a/css/starrate-main.css
+++ b/css/starrate-main.css
@@ -1,2 +1,2 @@
 /* extracted by css-entry-points-plugin */
-@import './Gallery-D2_t6yGf.chunk.css';
+@import './Gallery-kXsJ-YGE.chunk.css';

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -689,8 +689,12 @@ function onImgLoad() {
   previewError.value   = false
   previewRetries       = 0
   resetControlsTimer()
-  // Preload neighbors only after current image is ready — avoids bandwidth contention
-  preloadAdjacent(currentIndex.value)
+  // Fallback-Pfad (kein Thumb-Placeholder): Preview lädt direkt im <img>,
+  // hier ist "image ready" = "preview ready" → Nachbarn preloaden.
+  // Mit Thumb-Placeholder übernimmt das der img.onload / Cache-Hit-Zweig im watcher.
+  if (actualSrc.value === previewUrl.value) {
+    preloadAdjacent(currentIndex.value)
+  }
 }
 
 function onImgError() {
@@ -718,6 +722,8 @@ watch(previewUrl, (url) => {
     // Preview already cached by preloadAdjacent — show directly
     actualSrc.value      = url
     loadingPreview.value = false
+    // Preload neighbors now that current preview is ready — avoids bandwidth contention
+    preloadAdjacent(currentIndex.value)
     return
   }
 
@@ -744,6 +750,8 @@ watch(previewUrl, (url) => {
         if (previewUrl.value === url) {
           actualSrc.value      = url
           loadingPreview.value = false
+          // Preload neighbors only after current preview is ready — avoids bandwidth contention
+          preloadAdjacent(currentIndex.value)
         }
       })
     }


### PR DESCRIPTION
## Summary

- Moves `preloadAdjacent()` out of `onImgLoad` and into the actual preview-ready moments.
- Prevents neighbor previews from competing with the main preview for bandwidth while the `<img>` is still showing the thumbnail placeholder.

## Context

When a loupe opens, `watch(previewUrl)` first sets `actualSrc` to the (browser-cached) thumbnail as a placeholder, then loads the real preview in a background `new Image()` and swaps it in via rAF.

The `<img>` fires `onImgLoad` as soon as the thumb is visible — which used to trigger `preloadAdjacent` already, even though the full preview was still downloading. The code comment "avoids bandwidth contention" was no longer semantically accurate after the thumb-placeholder feature landed.

## Change

Preload now fires at the correct "preview ready" moments:

- `img.onload` of the background `Image()` (thumb-placeholder path)
- Cache-hit branch in the `previewUrl` watcher (already preloaded)
- `onImgLoad` only when `actualSrc === previewUrl` (fallback path without thumb)

`preloadAdjacent` is idempotent (checks `preloadedUrls.has(url)`), so the overlap between thumb-path and Fallback-condition is safe.

## Test plan

- [x] Vitest: 325/325 green
- [x] Deployed to sixpack, manual loupe navigation feels smoother on first open
- [ ] Verify no regression on no-thumb path (images opened without grid visit)