### PR TITLE
fix: ESC reliably closes Share/Export modals

### DIFF
--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -674,13 +674,17 @@ function onAppKeydown(e) {
   e.preventDefault()
 }
 
-// Escape auf Dokument-Ebene: schließt Modals von innen nach außen, dann Auswahl
+// Escape auf Dokument-Ebene: schließt Modals von innen nach außen, dann Auswahl.
+// Muss in Capture-Phase laufen, da NC einen eigenen ESC-Handler auf document hat,
+// der sonst zuerst feuert. Modals sind per Teleport in <body> — @keydown auf
+// .sr-app greift dort nicht, deshalb reicht nur onAppKeydown nicht aus.
 function onDocKeydown(e) {
   if (e.key !== 'Escape') return
-  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShortcuts.value)        { showShortcuts.value  = false; return }
+  const stop = () => { e.preventDefault(); e.stopPropagation(); e.stopImmediatePropagation() }
+  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
+  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
+  if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
+  if (showShortcuts.value)        { showShortcuts.value  = false; stop(); return }
   if (selectedIds.value.size > 0) { gridRef.value?.clearSelection?.() }
 }
 
@@ -739,7 +743,7 @@ function onVisibilityChange() {
 }
 
 onMounted(async () => {
-  document.addEventListener('keydown', onDocKeydown)
+  document.addEventListener('keydown', onDocKeydown, true)
   document.addEventListener('visibilitychange', onVisibilityChange)
   window.addEventListener('popstate', onPopState)
   startBackgroundSync()
@@ -766,7 +770,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  document.removeEventListener('keydown', onDocKeydown)
+  document.removeEventListener('keydown', onDocKeydown, true)
   document.removeEventListener('visibilitychange', onVisibilityChange)
   window.removeEventListener('popstate', onPopState)
   stopBackgroundSync()

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -680,7 +680,7 @@ function onAppKeydown(e) {
 // .sr-app greift dort nicht, deshalb reicht nur onAppKeydown nicht aus.
 function onDocKeydown(e) {
   if (e.key !== 'Escape') return
-  const stop = () => { e.preventDefault(); e.stopPropagation(); e.stopImmediatePropagation() }
+  const stop = () => { e.preventDefault(); e.stopPropagation() }
   if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
   if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
   if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }


### PR DESCRIPTION
## Summary
- Register `onDocKeydown` in capture phase so it runs before Nextcloud's own document-level ESC handler (which would otherwise navigate to the parent folder).
- Add `stopImmediatePropagation` on the modal-close branches to block NC's handler entirely while a StarRate modal is open.

## Why
Modals (Share, Export, ShareList) are rendered via `<Teleport to="body">`, so the `@keydown` listener on `.sr-app` never fires for events originating inside the modal. The previous document-level bubble listener ran after NC's handler, so ESC either did nothing visible or triggered a folder jump instead of closing the modal.
