### PR TITLE
fix: loupe footer on mobile — rating bar no longer overlaps image

### DIFF
--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -1311,10 +1311,10 @@ watch(() => props.initialIndex, idx => {
   .sr-loupe__comment-btn {
     order: 2;
     align-self: center;
-    padding: 4px 10px;
+    padding: 0 10px;
     margin: 0 0 0 14px;
   }
-  .sr-loupe__comment-icon { width: 20px; height: 20px; }
+  .sr-loupe__comment-icon { width: 26px; height: 26px; }
   .sr-loupe__comment-label { display: none; }
 }
 

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -1289,7 +1289,7 @@ watch(() => props.initialIndex, idx => {
     padding-bottom: max(72px, env(safe-area-inset-bottom));
     flex-wrap: wrap;
     justify-content: center;
-    gap: 6px 12px;
+    gap: 2px 12px;
   }
   /* Zeile 1: Steuerelemente */
   .sr-loupe__footer-center { order: 1; flex: 0 0 auto; justify-content: center; }

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -1311,10 +1311,10 @@ watch(() => props.initialIndex, idx => {
   .sr-loupe__comment-btn {
     order: 2;
     align-self: center;
-    padding: 8px 16px;
+    padding: 4px 10px;
     margin: 0 0 0 14px;
   }
-  .sr-loupe__comment-icon { width: 26px; height: 26px; }
+  .sr-loupe__comment-icon { width: 20px; height: 20px; }
   .sr-loupe__comment-label { display: none; }
 }
 


### PR DESCRIPTION
## Summary
- Tighten the mobile Loupe footer so the rating row stops bleeding ~4px into the photo.
- Shrink vertical padding of the comment button to 0 (icon stays 26×26) so its height matches the filename/index column.
- Reduce the footer row-gap from 6px to 2px so the filename sits closer to the rating row.

## Why
Commit 42b78ce enlarged the mobile comment button (padding 8×16 + 26×26 icon → ~42px tall). With `flex-wrap: wrap` and `align-items: center`, the second footer row grew to the button's height, pushing total footer height past the `.sr-loupe__stage { bottom: 150px }` mark and causing the rating row to overlap the bottom of the image.
