### PR TITLE
Nav-row cleanup: actions to FilterBar, folder popover, mobile polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 /dist/
 /build/
 /css/*.chunk.css
+/css/starrate-main.css
+/css/starrate-guest.css
+/css/starrate-settings.css
+/css/starrate-files-context.css
 
 # Dependencies
 /node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ bash.exe.stackdump
 
 # PHP
 *.log
+composer.phar
+composer.lock
+.phpunit.cache/

--- a/css/starrate-guest.css
+++ b/css/starrate-guest.css
@@ -1,3 +1,0 @@
-/* extracted by css-entry-points-plugin */
-@import './guest-bR0Rjup5.chunk.css';
-@import './Gallery-cnLjcDwV.chunk.css';

--- a/css/starrate-guest.css
+++ b/css/starrate-guest.css
@@ -1,3 +1,3 @@
 /* extracted by css-entry-points-plugin */
 @import './guest-bR0Rjup5.chunk.css';
-@import './Gallery-kXsJ-YGE.chunk.css';
+@import './Gallery-cnLjcDwV.chunk.css';

--- a/css/starrate-main.css
+++ b/css/starrate-main.css
@@ -1,2 +1,2 @@
 /* extracted by css-entry-points-plugin */
-@import './Gallery-kXsJ-YGE.chunk.css';
+@import './Gallery-cnLjcDwV.chunk.css';

--- a/css/starrate-main.css
+++ b/css/starrate-main.css
@@ -1,2 +1,0 @@
-/* extracted by css-entry-points-plugin */
-@import './Gallery-cnLjcDwV.chunk.css';

--- a/css/starrate-settings.css
+++ b/css/starrate-settings.css
@@ -1,2 +1,0 @@
-/* extracted by css-entry-points-plugin */
-@import './settings-CTqrPSTI.chunk.css';

--- a/css/starrate.css
+++ b/css/starrate.css
@@ -56,6 +56,43 @@
   overflow: hidden;
 }
 
+/* ── Kritische Layout-Regeln (FOUC-Schutz) ────────────────────────────────── */
+/* Diese Regeln liegen sonst in den async geladenen Gallery/FilterBar-Chunks.
+   Ohne sie kollabieren Nav-Row + FilterBar beim ersten Loupe-Einstieg auf 0px,
+   und der Loupe-Stage nimmt den gesamten Bildschirm ein („Vollbild-Flash").   */
+
+.sr-app {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: #1a1a2e;
+}
+.sr-app--loupe { background: #000; }
+
+.sr-nav-row { display: contents; }
+
+.sr-filterbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #12122a;
+  border-bottom: 1px solid #2a2a4a;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  min-height: 46px;
+}
+
+.sr-view-wrap {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
 /* ── Mobile ───────────────────────────────────────────────────────────────── */
 
 /* In Loupe-Ansicht auf Mobile: Nav-Zeile + FilterBar ausblenden */

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -12,6 +12,7 @@ OC.L10N.register(
         "Bewertung entfernen" : "Bewertung entfernen",
         "Bewertung:" : "Bewertung:",
         "%n Stern" : ["%n Stern", "%n Sterne"],
+        "%n Ordner" : ["%n Ordner", "%n Ordner"],
         "Bewertung konnte nicht gespeichert werden" : "Bewertung konnte nicht gespeichert werden",
         "{name}: {stars}" : "{name}: {stars}",
         "%n Bild bewertet %s" : ["%n Bild bewertet %s", "%n Bilder bewertet %s"],

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -9,6 +9,7 @@
     "Bewertung entfernen" : "Bewertung entfernen",
     "Bewertung:" : "Bewertung:",
     "%n Stern" : ["%n Stern", "%n Sterne"],
+    "%n Ordner" : ["%n Ordner", "%n Ordner"],
     "Bewertung konnte nicht gespeichert werden" : "Bewertung konnte nicht gespeichert werden",
     "{name}: {stars}" : "{name}: {stars}",
     "%n Bild bewertet %s" : ["%n Bild bewertet %s", "%n Bilder bewertet %s"],

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -12,6 +12,7 @@ OC.L10N.register(
         "Bewertung entfernen" : "Remove rating",
         "Bewertung:" : "Rating:",
         "%n Stern" : ["%n star", "%n stars"],
+        "%n Ordner" : ["%n folder", "%n folders"],
         "Bewertung konnte nicht gespeichert werden" : "Rating could not be saved",
         "{name}: {stars}" : "{name}: {stars}",
         "%n Bild bewertet %s" : ["%n image rated %s", "%n images rated %s"],

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -9,6 +9,7 @@
     "Bewertung entfernen" : "Remove rating",
     "Bewertung:" : "Rating:",
     "%n Stern" : ["%n star", "%n stars"],
+    "%n Ordner" : ["%n folder", "%n folders"],
     "Bewertung konnte nicht gespeichert werden" : "Rating could not be saved",
     "{name}: {stars}" : "{name}: {stars}",
     "%n Bild bewertet %s" : ["%n image rated %s", "%n images rated %s"],

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -91,9 +91,32 @@
         @click="resetFilters"
       >✕</button>
 
+      <!-- Mobile: Teilen/Export ans Ende der Scroll-Zone (selten genutzt, nicht prominent) -->
+      <div
+        v-if="allowShare || allowExport"
+        class="sr-filterbar__actions sr-filterbar__actions--mobile"
+      >
+        <div class="sr-filterbar__sep" aria-hidden="true" />
+        <button
+          v-if="allowShare"
+          class="sr-filterbar__action"
+          type="button"
+          :title="t('starrate', 'Freigabe-Links verwalten')"
+          @click="$emit('open-share-list')"
+        >{{ t('starrate', 'Teilen') }}</button>
+        <button
+          v-if="allowExport"
+          class="sr-filterbar__action"
+          type="button"
+          :disabled="!canExport"
+          :title="t('starrate', 'Bewertungsliste exportieren')"
+          @click="$emit('open-export-modal')"
+        >{{ t('starrate', 'Export') }}</button>
+      </div>
+
     </div>
 
-    <!-- Rechte Seite: Count + Reset + Modus -->
+    <!-- Rechte Seite: Count + Reset + Actions + Modus -->
     <div class="sr-filterbar__right">
       <!-- Aktive Filter: Count + Reset (immer gerendert, nur sichtbar wenn aktiv) -->
       <div class="sr-filterbar__status" :style="{ visibility: hasActiveFilter ? 'visible' : 'hidden' }">
@@ -109,6 +132,28 @@
           :tabindex="hasActiveFilter ? 0 : -1"
           @click="resetFilters"
         >{{ t('starrate', 'Alle anzeigen') }}</button>
+      </div>
+
+      <!-- Desktop: Teilen + Export (rechts vom Filter-Count, statisch sichtbar) -->
+      <div
+        v-if="allowShare || allowExport"
+        class="sr-filterbar__actions sr-filterbar__actions--desktop"
+      >
+        <button
+          v-if="allowShare"
+          class="sr-filterbar__action"
+          type="button"
+          :title="t('starrate', 'Freigabe-Links verwalten')"
+          @click="$emit('open-share-list')"
+        >{{ t('starrate', 'Teilen') }}</button>
+        <button
+          v-if="allowExport"
+          class="sr-filterbar__action"
+          type="button"
+          :disabled="!canExport"
+          :title="t('starrate', 'Bewertungsliste exportieren')"
+          @click="$emit('open-export-modal')"
+        >{{ t('starrate', 'Export') }}</button>
       </div>
 
       <!-- Modus-Umschalter -->
@@ -181,9 +226,21 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  allowShare: {
+    type: Boolean,
+    default: false,
+  },
+  allowExport: {
+    type: Boolean,
+    default: false,
+  },
+  canExport: {
+    type: Boolean,
+    default: false,
+  },
 })
 
-const emit = defineEmits(['update:filter', 'toggle-mode'])
+const emit = defineEmits(['update:filter', 'toggle-mode', 'open-share-list', 'open-export-modal'])
 
 const colorOptions = COLOR_OPTIONS
 
@@ -642,6 +699,59 @@ function updateFilter(newFilter) {
 /* Desktop: Toggle ist in der Nav-Zeile, hier ausblenden */
 @media (pointer: fine) {
   .sr-filterbar__mode { display: none; }
+}
+
+/* ── Teilen / Export Actions ──────────────────────────────────────────────── */
+.sr-filterbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.sr-filterbar__action {
+  padding: 2px 10px;
+  border-radius: 4px;
+  border: 1px solid #3f3f5a;
+  background: #2a2a3e;
+  color: #a1a1aa;
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 150ms, border-color 150ms, background 150ms;
+  box-shadow: none !important;
+  appearance: none !important;
+  -webkit-appearance: none !important;
+  min-height: 0;
+  line-height: 1.6;
+}
+
+@media (pointer: fine) {
+  .sr-filterbar__action:hover {
+    color: #d4d4d8;
+    border-color: #7a3050;
+    background: #32323e;
+  }
+}
+
+.sr-filterbar__action:focus,
+.sr-filterbar__action:focus-visible,
+.sr-filterbar__action:active {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.sr-filterbar__action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Desktop-Variante: nur auf Maus-Geräten */
+.sr-filterbar__actions--mobile { display: none; }
+@media (pointer: coarse) {
+  .sr-filterbar__actions--desktop { display: none; }
+  .sr-filterbar__actions--mobile  { display: flex; }
 }
 
 /* ── Mobile: single row, horizontal scroll ────────────────────────────────── */

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -638,8 +638,8 @@ function updateFilter(newFilter) {
 
 /* ── Anzahl ───────────────────────────────────────────────────────────────── */
 .sr-filterbar__count {
-  font-size: 11px;
-  color: #666;
+  font-size: 12px;
+  color: #a1a1aa;
   white-space: nowrap;
 }
 

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sr-filterbar">
     <!-- Linke Seite: Filter -->
-    <div class="sr-filterbar__filters" role="toolbar" :aria-label="t('starrate', 'Bildfilter')">
+    <div ref="filtersEl" class="sr-filterbar__filters" role="toolbar" :aria-label="t('starrate', 'Bildfilter')">
       <!-- Trichter-Icon -->
       <svg class="sr-filterbar__funnel" :class="{ 'sr-filterbar__funnel--active': hasActiveFilter }" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <path d="M3 4h18l-7 8v6l-4 2V12L3 4z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
@@ -194,7 +194,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import { t, n } from '@nextcloud/l10n'
 
 const COLOR_OPTIONS = [
@@ -247,6 +247,28 @@ const colorOptions = COLOR_OPTIONS
 // ─── Rating-Filter ────────────────────────────────────────────────────────────
 
 const selectedOp = ref('≥')
+const filtersEl  = ref(null)
+
+// Scroll-Hint auf Mobile: einmal pro Session kurz nach rechts wippen, damit
+// erkennbar wird, dass die Filter-Zeile horizontal scrollbar ist.
+onMounted(async () => {
+  await nextTick()
+  const el = filtersEl.value
+  if (!el) return
+  if (typeof window === 'undefined' || !window.matchMedia) return
+  if (!window.matchMedia('(pointer: coarse)').matches) return
+  if (el.scrollWidth <= el.clientWidth + 4) return
+  try {
+    if (sessionStorage.getItem('sr-filterbar-hint')) return
+    sessionStorage.setItem('sr-filterbar-hint', '1')
+  } catch (e) { /* sessionStorage evtl. blockiert */ }
+
+  // Sanft anschubsen und zurück — nicht zu grell
+  const steps = [8, 16, 8, 0]
+  steps.forEach((x, i) => setTimeout(() => {
+    el.scrollTo({ left: x, behavior: 'smooth' })
+  }, 400 + i * 220))
+})
 
 // selectedOp mit eingehendem Filter synchronisieren (z.B. aus localStorage)
 watch(() => props.filter, (f) => {

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -260,13 +260,13 @@ onMounted(async () => {
   if (!el) return
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
   let mq
-  try { mq = window.matchMedia('(max-width: 640px)') } catch (e) { return }
+  try { mq = window.matchMedia('(max-width: 640px)') } catch { return }
   if (!mq || !mq.matches) return
   if (el.scrollWidth <= el.clientWidth + 4) return
   try {
     if (sessionStorage.getItem('sr-filterbar-hint')) return
     sessionStorage.setItem('sr-filterbar-hint', '1')
-  } catch (e) { /* sessionStorage evtl. blockiert */ }
+  } catch { /* sessionStorage evtl. blockiert */ }
 
   // Sanft anschubsen und zurück — nicht zu grell
   const steps = [8, 16, 8, 0]

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -724,7 +724,7 @@ function updateFilter(newFilter) {
 
 
 /* Desktop: Toggle ist in der Nav-Zeile, hier ausblenden */
-@media (pointer: fine) {
+@media (min-width: 641px) {
   .sr-filterbar__mode { display: none; }
 }
 

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -256,7 +256,7 @@ onMounted(async () => {
   const el = filtersEl.value
   if (!el) return
   if (typeof window === 'undefined' || !window.matchMedia) return
-  if (!window.matchMedia('(pointer: coarse)').matches) return
+  if (!window.matchMedia('(max-width: 640px)').matches) return
   if (el.scrollWidth <= el.clientWidth + 4) return
   try {
     if (sessionStorage.getItem('sr-filterbar-hint')) return
@@ -769,15 +769,15 @@ function updateFilter(newFilter) {
   cursor: not-allowed;
 }
 
-/* Desktop-Variante: nur auf Maus-Geräten */
+/* Desktop-Variante: nur auf Maus-Geräten ODER breitem Viewport */
 .sr-filterbar__actions--mobile { display: none; }
-@media (pointer: coarse) {
+@media (max-width: 640px) {
   .sr-filterbar__actions--desktop { display: none; }
   .sr-filterbar__actions--mobile  { display: flex; }
 }
 
 /* ── Mobile: single row, horizontal scroll ────────────────────────────────── */
-@media (pointer: coarse) {
+@media (max-width: 640px) {
   .sr-filterbar {
     flex-wrap: nowrap;
     padding: 5px 8px;

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -118,18 +118,21 @@
 
     <!-- Rechte Seite: Count + Reset + Actions + Modus -->
     <div class="sr-filterbar__right">
-      <!-- Aktive Filter: Count + Reset (immer gerendert, nur sichtbar wenn aktiv) -->
-      <div class="sr-filterbar__status" :style="{ visibility: hasActiveFilter ? 'visible' : 'hidden' }">
+      <!-- Count: immer sichtbar. Reset: nur bei aktivem Filter. -->
+      <div class="sr-filterbar__status">
         <span class="sr-filterbar__count" aria-live="polite">
-          {{ n('starrate', '%n Bild', '%n Bilder', filteredCount) }}
-          <span class="sr-filterbar__count-sep">/</span>
-          {{ n('starrate', '%n gesamt', '%n gesamt', total) }}
+          <template v-if="hasActiveFilter">
+            {{ t('starrate', '{filtered} von {total}', { filtered: filteredCount, total }) }}
+          </template>
+          <template v-else>
+            {{ n('starrate', '%n Bild', '%n Bilder', total) }}
+          </template>
         </span>
         <button
+          v-if="hasActiveFilter"
           class="sr-filterbar__reset"
           type="button"
           :aria-label="t('starrate', 'Alle Filter zurücksetzen')"
-          :tabindex="hasActiveFilter ? 0 : -1"
           @click="resetFilters"
         >{{ t('starrate', 'Alle anzeigen') }}</button>
       </div>

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -258,8 +258,10 @@ onMounted(async () => {
   await nextTick()
   const el = filtersEl.value
   if (!el) return
-  if (typeof window === 'undefined' || !window.matchMedia) return
-  if (!window.matchMedia('(max-width: 640px)').matches) return
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+  let mq
+  try { mq = window.matchMedia('(max-width: 640px)') } catch (e) { return }
+  if (!mq || !mq.matches) return
   if (el.scrollWidth <= el.clientWidth + 4) return
   try {
     if (sessionStorage.getItem('sr-filterbar-hint')) return

--- a/src/components/FolderPopover.vue
+++ b/src/components/FolderPopover.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="sr-folder-popover">
+    <button
+      class="sr-folder-popover__trigger"
+      type="button"
+      :title="t('starrate', 'Unterordner')"
+      :aria-expanded="open"
+      aria-haspopup="menu"
+      @click="toggle"
+    >
+      📁 {{ folders.length }}
+      <span class="sr-folder-popover__caret" aria-hidden="true">▾</span>
+    </button>
+
+    <Teleport v-if="open" to="body">
+      <div
+        class="sr-folder-popover__catcher"
+        @click="close"
+        @wheel="close"
+        @touchmove="close"
+      ></div>
+      <div
+        ref="menuRef"
+        class="sr-folder-popover__menu"
+        :style="menuStyle"
+        role="menu"
+      >
+        <button
+          v-for="(f, i) in folders"
+          :key="f.path"
+          ref="itemRefs"
+          class="sr-folder-popover__item"
+          type="button"
+          role="menuitem"
+          :tabindex="i === 0 ? 0 : -1"
+          @click="select(f)"
+          @keydown.down.prevent="focusItem(i + 1)"
+          @keydown.up.prevent="focusItem(i - 1)"
+        >
+          <span class="sr-folder-popover__icon" aria-hidden="true">📁</span>
+          <span class="sr-folder-popover__name">{{ f.name }}</span>
+        </button>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+import { ref, nextTick, onUnmounted } from 'vue'
+import { t } from '@nextcloud/l10n'
+
+defineProps({
+  folders: {
+    type: Array,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['navigate'])
+
+const open      = ref(false)
+const menuStyle = ref({})
+const menuRef   = ref(null)
+const itemRefs  = ref([])
+
+// Position des Triggers merken, damit wir Menüposition berechnen können
+let triggerEl = null
+
+function toggle(e) {
+  triggerEl = e.currentTarget
+  if (open.value) {
+    close()
+  } else {
+    openMenu()
+  }
+}
+
+async function openMenu() {
+  computePosition()
+  open.value = true
+  await nextTick()
+  // Nach dem Render: Menü-Höhe neu messen und ggf. Flip nach oben
+  recomputePosition()
+  // Escape-Listener global (Teleport landet in body, kein natives Keydown sonst)
+  document.addEventListener('keydown', onDocKeydown, true)
+  // Focus erstes Item
+  itemRefs.value[0]?.focus()
+}
+
+function close() {
+  if (!open.value) return
+  open.value = false
+  document.removeEventListener('keydown', onDocKeydown, true)
+  triggerEl?.focus?.()
+}
+
+function onDocKeydown(e) {
+  if (e.key === 'Escape') {
+    e.stopPropagation()
+    close()
+  }
+}
+
+function computePosition() {
+  if (!triggerEl) return
+  const rect = triggerEl.getBoundingClientRect()
+  menuStyle.value = {
+    position: 'fixed',
+    top:   `${rect.bottom + 4}px`,
+    left:  `${Math.max(8, rect.right - 240)}px`,   // rechtsbündig, min 8px vom linken Rand
+    minWidth: `${Math.max(180, rect.width)}px`,
+  }
+}
+
+function recomputePosition() {
+  if (!triggerEl || !menuRef.value) return
+  const rect = triggerEl.getBoundingClientRect()
+  const menuH = menuRef.value.offsetHeight
+  const viewportH = window.innerHeight
+  // Flip nach oben, wenn unten kein Platz
+  const top = (rect.bottom + 4 + menuH > viewportH && rect.top - 4 - menuH > 0)
+    ? rect.top - 4 - menuH
+    : rect.bottom + 4
+  menuStyle.value = {
+    ...menuStyle.value,
+    top:  `${top}px`,
+  }
+}
+
+function select(folder) {
+  emit('navigate', folder.path)
+  close()
+}
+
+function focusItem(idx) {
+  const items = itemRefs.value
+  if (!items.length) return
+  const n = (idx + items.length) % items.length
+  items[n]?.focus()
+}
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', onDocKeydown, true)
+})
+
+defineExpose({ close })
+</script>
+
+<style scoped>
+.sr-folder-popover {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.sr-folder-popover__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #1a1a2e;
+  border: 1px solid #2a2a4a;
+  border-radius: 4px;
+  color: #a1a1aa;
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-left: 6px;
+  font-family: inherit;
+  transition: color 0.15s, border-color 0.15s;
+  box-shadow: none !important;
+  appearance: none !important;
+  -webkit-appearance: none !important;
+}
+
+.sr-folder-popover__trigger:hover {
+  color: #d4d4d8;
+  border-color: #5a5a8a;
+}
+
+.sr-folder-popover__trigger:focus,
+.sr-folder-popover__trigger:focus-visible,
+.sr-folder-popover__trigger:active {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.sr-folder-popover__caret {
+  font-size: 9px;
+  opacity: 0.7;
+}
+
+/* Desktop: Popover-Trigger ausblenden — Kind-Ordner sind als Pills (sr-folders) sichtbar */
+@media (pointer: fine) {
+  .sr-folder-popover { display: none; }
+}
+</style>
+
+<style>
+/* Teleport-Children (body) können nicht scoped werden */
+.sr-folder-popover__catcher {
+  position: fixed;
+  inset: 0;
+  background: transparent;
+  z-index: 8000;
+}
+
+.sr-folder-popover__menu {
+  z-index: 8001;
+  background: #16213e;
+  border: 1px solid #2a2a4a;
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  padding: 4px 0;
+  max-height: 60vh;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #2a2a4a transparent;
+  display: flex;
+  flex-direction: column;
+}
+
+.sr-folder-popover__menu::-webkit-scrollbar { width: 6px; }
+.sr-folder-popover__menu::-webkit-scrollbar-thumb { background: #2a2a4a; border-radius: 3px; }
+
+.sr-folder-popover__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: transparent;
+  border: none;
+  color: #d4d4d8;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+  min-height: 36px;
+  box-shadow: none !important;
+  appearance: none !important;
+  -webkit-appearance: none !important;
+}
+
+.sr-folder-popover__item:hover,
+.sr-folder-popover__item:focus,
+.sr-folder-popover__item:focus-visible {
+  background: #1f2d4e;
+  outline: none !important;
+  box-shadow: none !important;
+  color: #fff;
+}
+
+.sr-folder-popover__icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.sr-folder-popover__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 260px;
+}
+</style>

--- a/src/components/FolderPopover.vue
+++ b/src/components/FolderPopover.vue
@@ -105,28 +105,41 @@ function onDocKeydown(e) {
 function computePosition() {
   if (!triggerEl) return
   const rect = triggerEl.getBoundingClientRect()
-  // Menü immer rechtsbündig am Trigger ausrichten — so wandert es nicht mysteriös herum
-  const rightFromViewport = Math.max(8, window.innerWidth - rect.right)
+  // Initiale Positionierung rechtsbündig am Trigger — wird nach Render in
+  // recomputePosition() auf tatsächliche Menübreite nachgeklemmt.
+  const viewportW = window.innerWidth
   menuStyle.value = {
     position: 'fixed',
     top:   `${rect.bottom + 4}px`,
-    right: `${rightFromViewport}px`,
+    left:  `${Math.max(8, Math.min(rect.right - 240, viewportW - 248))}px`,
     minWidth: '200px',
-    maxWidth: `${window.innerWidth - 16}px`,
+    maxWidth: `${viewportW - 16}px`,
   }
 }
 
 function recomputePosition() {
   if (!triggerEl || !menuRef.value) return
   const rect = triggerEl.getBoundingClientRect()
+  const menuW = menuRef.value.offsetWidth
   const menuH = menuRef.value.offsetHeight
+  const viewportW = window.innerWidth
   const viewportH = window.innerHeight
+
+  // Wunsch: Menü rechtsbündig am Trigger (right edges aligned)
+  let left = rect.right - menuW
+  // Nach rechts clampen (nicht über Viewport-Rand hinaus)
+  if (left + menuW > viewportW - 8) left = viewportW - 8 - menuW
+  // Nach links clampen (mindestens 8px vom linken Viewport-Rand)
+  if (left < 8) left = 8
+
   // Flip nach oben, wenn unten kein Platz
   const top = (rect.bottom + 4 + menuH > viewportH && rect.top - 4 - menuH > 0)
     ? rect.top - 4 - menuH
     : rect.bottom + 4
+
   menuStyle.value = {
     ...menuStyle.value,
+    left: `${left}px`,
     top:  `${top}px`,
   }
 }

--- a/src/components/FolderPopover.vue
+++ b/src/components/FolderPopover.vue
@@ -209,7 +209,7 @@ defineExpose({ close })
 }
 
 /* Desktop: Popover-Trigger ausblenden — Kind-Ordner sind als Pills (sr-folders) sichtbar */
-@media (pointer: fine) {
+@media (min-width: 641px) {
   .sr-folder-popover { display: none; }
 }
 </style>

--- a/src/components/FolderPopover.vue
+++ b/src/components/FolderPopover.vue
@@ -152,8 +152,8 @@ function select(folder) {
 function focusItem(idx) {
   const items = itemRefs.value
   if (!items.length) return
-  const n = (idx + items.length) % items.length
-  items[n]?.focus()
+  const target = (idx + items.length) % items.length
+  items[target]?.focus()
 }
 
 onUnmounted(() => {

--- a/src/components/FolderPopover.vue
+++ b/src/components/FolderPopover.vue
@@ -8,7 +8,8 @@
       aria-haspopup="menu"
       @click="toggle"
     >
-      📁 {{ folders.length }}
+      <span aria-hidden="true">📁</span>
+      {{ n('starrate', '%n Ordner', '%n Ordner', folders.length) }}
       <span class="sr-folder-popover__caret" aria-hidden="true">▾</span>
     </button>
 
@@ -47,7 +48,7 @@
 
 <script setup>
 import { ref, nextTick, onUnmounted } from 'vue'
-import { t } from '@nextcloud/l10n'
+import { t, n } from '@nextcloud/l10n'
 
 defineProps({
   folders: {
@@ -104,11 +105,14 @@ function onDocKeydown(e) {
 function computePosition() {
   if (!triggerEl) return
   const rect = triggerEl.getBoundingClientRect()
+  // Menü immer rechtsbündig am Trigger ausrichten — so wandert es nicht mysteriös herum
+  const rightFromViewport = Math.max(8, window.innerWidth - rect.right)
   menuStyle.value = {
     position: 'fixed',
     top:   `${rect.bottom + 4}px`,
-    left:  `${Math.max(8, rect.right - 240)}px`,   // rechtsbündig, min 8px vom linken Rand
-    minWidth: `${Math.max(180, rect.width)}px`,
+    right: `${rightFromViewport}px`,
+    minWidth: '200px',
+    maxWidth: `${window.innerWidth - 16}px`,
   }
 }
 

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -31,7 +31,7 @@
         @dblclick="$emit('open-loupe', image, index)"
       >
         <!-- Thumbnail -->
-        <div class="sr-grid__thumb-wrap" style="position:relative; padding-top:75%; overflow:hidden;">
+        <div class="sr-grid__thumb-wrap">
           <img
             v-if="image.thumbLoaded"
             class="sr-grid__thumb"
@@ -39,9 +39,8 @@
             :alt="image.name"
             loading="lazy"
             draggable="false"
-            style="position:absolute; inset:0; width:100%; height:100%; object-fit:cover; display:block;"
           />
-          <div v-else class="sr-grid__thumb-placeholder" :class="{ 'sr-grid__thumb-placeholder--error': image.thumbError }" style="position:absolute; inset:0;" />
+          <div v-else class="sr-grid__thumb-placeholder" :class="{ 'sr-grid__thumb-placeholder--error': image.thumbError }" />
 
           <!-- Pick-Badge -->
           <div v-if="enablePickUi && image.pick === 'pick'" class="sr-grid__pick-badge" aria-label="Picked">
@@ -158,20 +157,14 @@ const emit = defineEmits([
 const THUMB_SIZE = 280
 
 const gridStyle = computed(() => {
-  // display/gap/padding als Inline-Style: verhindert FOUC (volle Bildgroesse beim
-  // ersten Paint), falls das async geladene Gallery-Chunk-CSS noch nicht da ist.
-  const base = {
-    display: 'grid',
-    gap: '6px',
-    padding: '8px',
-    alignContent: 'start',
-  }
+  // gridTemplateColumns direkt als Inline-Style – CSS-custom-properties mit repeat()
+  // werden in einigen Browsern nicht korrekt in grid-template-columns geparsed.
   if (props.gridColumns !== 'auto') {
-    return { ...base, gridTemplateColumns: `repeat(${props.gridColumns}, 1fr)` }
+    return { gridTemplateColumns: `repeat(${props.gridColumns}, 1fr)` }
   }
   // min() stellt sicher dass auf Mobile mindestens 2 Spalten passen:
   // min(280px, calc(50vw - 16px)) → Desktop: 280px, Mobile 390px: ~179px → 2 Spalten
-  return { ...base, gridTemplateColumns: `repeat(auto-fill, minmax(min(${THUMB_SIZE}px, calc(50vw - 16px)), 1fr))` }
+  return { gridTemplateColumns: `repeat(auto-fill, minmax(min(${THUMB_SIZE}px, calc(50vw - 16px)), 1fr))` }
 })
 
 // ─── Zustand ──────────────────────────────────────────────────────────────────

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -158,14 +158,20 @@ const emit = defineEmits([
 const THUMB_SIZE = 280
 
 const gridStyle = computed(() => {
-  // gridTemplateColumns direkt als Inline-Style – CSS-custom-properties mit repeat()
-  // werden in einigen Browsern nicht korrekt in grid-template-columns geparsed.
+  // display/gap/padding als Inline-Style: verhindert FOUC (volle Bildgroesse beim
+  // ersten Paint), falls das async geladene Gallery-Chunk-CSS noch nicht da ist.
+  const base = {
+    display: 'grid',
+    gap: '6px',
+    padding: '8px',
+    alignContent: 'start',
+  }
   if (props.gridColumns !== 'auto') {
-    return { gridTemplateColumns: `repeat(${props.gridColumns}, 1fr)` }
+    return { ...base, gridTemplateColumns: `repeat(${props.gridColumns}, 1fr)` }
   }
   // min() stellt sicher dass auf Mobile mindestens 2 Spalten passen:
   // min(280px, calc(50vw - 16px)) → Desktop: 280px, Mobile 390px: ~179px → 2 Spalten
-  return { gridTemplateColumns: `repeat(auto-fill, minmax(min(${THUMB_SIZE}px, calc(50vw - 16px)), 1fr))` }
+  return { ...base, gridTemplateColumns: `repeat(auto-fill, minmax(min(${THUMB_SIZE}px, calc(50vw - 16px)), 1fr))` }
 })
 
 // ─── Zustand ──────────────────────────────────────────────────────────────────

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -31,7 +31,7 @@
         @dblclick="$emit('open-loupe', image, index)"
       >
         <!-- Thumbnail -->
-        <div class="sr-grid__thumb-wrap">
+        <div class="sr-grid__thumb-wrap" style="position:relative; padding-top:75%; overflow:hidden;">
           <img
             v-if="image.thumbLoaded"
             class="sr-grid__thumb"
@@ -39,8 +39,9 @@
             :alt="image.name"
             loading="lazy"
             draggable="false"
+            style="position:absolute; inset:0; width:100%; height:100%; object-fit:cover; display:block;"
           />
-          <div v-else class="sr-grid__thumb-placeholder" :class="{ 'sr-grid__thumb-placeholder--error': image.thumbError }" />
+          <div v-else class="sr-grid__thumb-placeholder" :class="{ 'sr-grid__thumb-placeholder--error': image.thumbError }" style="position:absolute; inset:0;" />
 
           <!-- Pick-Badge -->
           <div v-if="enablePickUi && image.pick === 'pick'" class="sr-grid__pick-badge" aria-label="Picked">

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -1311,10 +1311,10 @@ watch(() => props.initialIndex, idx => {
   .sr-loupe__comment-btn {
     order: 2;
     align-self: center;
-    padding: 4px 10px;
+    padding: 0 10px;
     margin: 0 0 0 14px;
   }
-  .sr-loupe__comment-icon { width: 20px; height: 20px; }
+  .sr-loupe__comment-icon { width: 26px; height: 26px; }
   .sr-loupe__comment-label { display: none; }
 }
 

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -1289,7 +1289,7 @@ watch(() => props.initialIndex, idx => {
     padding-bottom: max(72px, env(safe-area-inset-bottom));
     flex-wrap: wrap;
     justify-content: center;
-    gap: 6px 12px;
+    gap: 2px 12px;
   }
   /* Zeile 1: Steuerelemente */
   .sr-loupe__footer-center { order: 1; flex: 0 0 auto; justify-content: center; }

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -2,6 +2,7 @@
   <div
     class="sr-loupe"
     ref="loupeEl"
+    style="position:relative; width:100%; height:100%; background:#000; overflow:hidden;"
     @wheel.prevent="onWheel"
     @dblclick="onDblClick"
     @mousedown="onMouseDown"
@@ -17,6 +18,7 @@
       <div
         class="sr-loupe__stage"
         :key="currentIndex"
+        style="position:absolute; inset:0;"
       >
         <img
           v-if="currentImage && !previewError"
@@ -330,14 +332,30 @@ const zoomLabel = computed(() => {
   return `${Math.round(zoom.value * 100)}%`
 })
 
+// Kritische Layout-Regeln als Inline-Style (verhindert FOUC, falls das async
+// geladene LoupeView-Chunk-CSS noch nicht da ist): absolute + centered +
+// max-width/-height auf 100% + object-fit:contain.
+const imgBaseStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  maxWidth: '100%',
+  maxHeight: '100%',
+  objectFit: 'contain',
+  userSelect: 'none',
+  WebkitUserDrag: 'none',
+}
+
 const imgStyle = computed(() => {
   if (isFit.value) {
     return {
+      ...imgBaseStyle,
       transform: 'translate(-50%, -50%) scale(1)',
       cursor: 'default',
     }
   }
   return {
+    ...imgBaseStyle,
     transform: `translate(calc(-50% + ${panX.value}px), calc(-50% + ${panY.value}px)) scale(${zoom.value})`,
     cursor: isPanning.value ? 'grabbing' : (zoom.value > 1 ? 'grab' : 'default'),
     transformOrigin: 'center center',

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -2,7 +2,6 @@
   <div
     class="sr-loupe"
     ref="loupeEl"
-    style="position:relative; width:100%; height:100%; background:#000; overflow:hidden;"
     @wheel.prevent="onWheel"
     @dblclick="onDblClick"
     @mousedown="onMouseDown"
@@ -18,7 +17,6 @@
       <div
         class="sr-loupe__stage"
         :key="currentIndex"
-        style="position:absolute; inset:0;"
       >
         <img
           v-if="currentImage && !previewError"
@@ -332,30 +330,14 @@ const zoomLabel = computed(() => {
   return `${Math.round(zoom.value * 100)}%`
 })
 
-// Kritische Layout-Regeln als Inline-Style (verhindert FOUC, falls das async
-// geladene LoupeView-Chunk-CSS noch nicht da ist): absolute + centered +
-// max-width/-height auf 100% + object-fit:contain.
-const imgBaseStyle = {
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
-  maxWidth: '100%',
-  maxHeight: '100%',
-  objectFit: 'contain',
-  userSelect: 'none',
-  WebkitUserDrag: 'none',
-}
-
 const imgStyle = computed(() => {
   if (isFit.value) {
     return {
-      ...imgBaseStyle,
       transform: 'translate(-50%, -50%) scale(1)',
       cursor: 'default',
     }
   }
   return {
-    ...imgBaseStyle,
     transform: `translate(calc(-50% + ${panX.value}px), calc(-50% + ${panY.value}px)) scale(${zoom.value})`,
     cursor: isPanning.value ? 'grabbing' : (zoom.value > 1 ? 'grab' : 'default'),
     transformOrigin: 'center center',

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -1311,10 +1311,10 @@ watch(() => props.initialIndex, idx => {
   .sr-loupe__comment-btn {
     order: 2;
     align-self: center;
-    padding: 8px 16px;
+    padding: 4px 10px;
     margin: 0 0 0 14px;
   }
-  .sr-loupe__comment-icon { width: 26px; height: 26px; }
+  .sr-loupe__comment-icon { width: 20px; height: 20px; }
   .sr-loupe__comment-label { display: none; }
 }
 

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -687,6 +687,8 @@ function onAppKeydown(e) {
 // .sr-app greift dort nicht, deshalb reicht nur onAppKeydown nicht aus.
 function onDocKeydown(e) {
   if (e.key !== 'Escape') return
+  // FolderPopover schließt sich selbst — nicht zusätzlich Selektion räumen
+  if (document.querySelector('.sr-folder-popover__menu')) return
   const stop = () => { e.preventDefault(); e.stopPropagation() }
   if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
   if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sr-app" :class="{ 'sr-app--loupe': mode === 'loupe' }" @keydown="onAppKeydown">
 
-    <!-- Nav-Zeile: Breadcrumb + Unterordner (auf Mobile eine scrollbare Zeile) -->
+    <!-- Nav-Zeile: Breadcrumb + Unterordner -->
     <div class="sr-nav-row">
       <div class="sr-breadcrumb">
         <button class="sr-breadcrumb__seg" @click="navigateTo('/')">⌂</button>
@@ -9,68 +9,69 @@
           <span class="sr-breadcrumb__sep">/</span>
           <button class="sr-breadcrumb__seg" @click="navigateTo(pathUpTo(i))">{{ seg }}</button>
         </template>
-        <button v-if="!guestMode" class="sr-breadcrumb__share" @click="showShareList = true" :title="t('starrate', 'Freigabe-Links verwalten')">
-          {{ t('starrate', 'Teilen') }}
-        </button>
-        <button
-          v-if="!guestMode || allowExport"
-          class="sr-breadcrumb__share"
-          :disabled="filteredImages.length === 0"
-          :title="t('starrate', 'Bewertungsliste exportieren')"
-          @click="showExportModal = true"
-        >{{ t('starrate', 'Export') }}</button>
+
+        <!-- Mobile-only: Unterordner-Popover am Ende des Pfads -->
+        <FolderPopover
+          v-if="subFolders.length && mode !== 'loupe'"
+          :folders="subFolders"
+          @navigate="navigateTo"
+        />
+
         <span v-if="guestMode && guestLabel" class="sr-breadcrumb__guest-label">{{ guestLabel }}</span>
-        <!-- Modus-Toggle: nur Desktop (Mobile: in FilterBar) -->
-        <div class="sr-breadcrumb__mode">
-          <button
-            class="sr-breadcrumb__mode-btn"
-            :class="{ 'sr-breadcrumb__mode-btn--active': mode === 'grid' }"
-            type="button"
-            :title="t('starrate', 'Rasteransicht')"
-            @click="toggleMode"
-          >
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <rect x="3" y="3" width="7" height="7" rx="1" fill="currentColor"/>
-              <rect x="14" y="3" width="7" height="7" rx="1" fill="currentColor"/>
-              <rect x="3" y="14" width="7" height="7" rx="1" fill="currentColor"/>
-              <rect x="14" y="14" width="7" height="7" rx="1" fill="currentColor"/>
-            </svg>
-          </button>
-          <button
-            class="sr-breadcrumb__mode-btn"
-            :class="{ 'sr-breadcrumb__mode-btn--active': mode === 'loupe' }"
-            type="button"
-            :title="t('starrate', 'Lupenansicht')"
-            @click="toggleMode"
-          >
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <rect x="2" y="2" width="20" height="20" rx="2" stroke="currentColor" stroke-width="2"/>
-              <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="2"/>
-            </svg>
-          </button>
+
+        <!-- Utility-Cluster (Desktop-only via CSS): Modus-Toggle, Help, Version -->
+        <div class="sr-breadcrumb__utility">
+          <div class="sr-breadcrumb__mode">
+            <button
+              class="sr-breadcrumb__mode-btn"
+              :class="{ 'sr-breadcrumb__mode-btn--active': mode === 'grid' }"
+              type="button"
+              :title="t('starrate', 'Rasteransicht')"
+              @click="toggleMode"
+            >
+              <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="3" y="3" width="7" height="7" rx="1" fill="currentColor"/>
+                <rect x="14" y="3" width="7" height="7" rx="1" fill="currentColor"/>
+                <rect x="3" y="14" width="7" height="7" rx="1" fill="currentColor"/>
+                <rect x="14" y="14" width="7" height="7" rx="1" fill="currentColor"/>
+              </svg>
+            </button>
+            <button
+              class="sr-breadcrumb__mode-btn"
+              :class="{ 'sr-breadcrumb__mode-btn--active': mode === 'loupe' }"
+              type="button"
+              :title="t('starrate', 'Lupenansicht')"
+              @click="toggleMode"
+            >
+              <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="2" stroke="currentColor" stroke-width="2"/>
+                <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+          </div>
+
+          <!-- Shortcut-Hilfe -->
+          <button class="sr-breadcrumb__help" :title="t('starrate', 'Tastaturkürzel')" @click="showShortcuts = true">?</button>
+
+          <span class="sr-breadcrumb__version">
+            StarRate v{{ appVersion }}<br/>
+            by <a href="https://www.instagram.com/merlin1.de/" target="_blank" rel="noopener noreferrer" class="sr-breadcrumb__version-link">Merlin1.De</a>
+          </span>
         </div>
-
-        <!-- Shortcut-Hilfe -->
-        <button class="sr-breadcrumb__help" :title="t('starrate', 'Tastaturkürzel')" @click="showShortcuts = true">?</button>
-
-        <span class="sr-breadcrumb__version">
-          StarRate v{{ appVersion }}<br/>
-          by <a href="https://www.instagram.com/merlin1.de/" target="_blank" rel="noopener noreferrer" class="sr-breadcrumb__version-link">Merlin1.De</a>
-        </span>
       </div>
 
-      <!-- Unterordner (in Loupe ausgeblendet) -->
+      <!-- Desktop-only: Unterordner-Pills als eigene Zeile -->
       <div v-if="subFolders.length && mode !== 'loupe'" class="sr-folders">
-      <button
-        v-for="f in subFolders"
-        :key="f.path"
-        class="sr-folders__item"
-        @click="navigateTo(f.path)"
-      >
-        <span class="sr-folders__icon">📁</span>
-        <span class="sr-folders__name">{{ f.name }}</span>
-      </button>
-    </div>
+        <button
+          v-for="f in subFolders"
+          :key="f.path"
+          class="sr-folders__item"
+          @click="navigateTo(f.path)"
+        >
+          <span class="sr-folders__icon">📁</span>
+          <span class="sr-folders__name">{{ f.name }}</span>
+        </button>
+      </div>
     </div><!-- /.sr-nav-row -->
 
     <!-- Filterleiste -->
@@ -80,7 +81,12 @@
       :filtered-count="filteredImages.length"
       :mode="mode"
       :enable-pick-ui="settings.enable_pick_ui"
+      :allow-share="!guestMode"
+      :allow-export="!guestMode || allowExport"
+      :can-export="filteredImages.length > 0"
       @toggle-mode="toggleMode"
+      @open-share-list="showShareList = true"
+      @open-export-modal="showExportModal = true"
     />
 
     <!-- Ansichts-Wrapper: nimmt den restlichen Platz, gibt dem Grid eine definite Höhe -->
@@ -241,6 +247,7 @@ import LoupeView from '../components/LoupeView.vue'
 import ShareModal from '../components/ShareModal.vue'
 import ShareList from '../components/ShareList.vue'
 import ExportModal from '../components/ExportModal.vue'
+import FolderPopover from '../components/FolderPopover.vue'
 
 // ─── Gast-Modus-Props (alle optional, Defaults = normales Verhalten) ───────────
 
@@ -889,27 +896,12 @@ watch(() => route.query, q => {
   min-height: 0;
 }
 
-.sr-breadcrumb__share {
-  background: #2a2a3e;
-  border: 1px solid #3f3f5a;
-  border-radius: 4px;
-  color: #a1a1aa;
-  cursor: pointer;
-  font-size: 11px;
-  padding: 2px 8px;
-  white-space: nowrap;
+.sr-breadcrumb__utility {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
   flex-shrink: 0;
-  transition: color 0.15s, border-color 0.15s;
-}
-.sr-breadcrumb__share:hover {
-  color: #d4d4d8;
-  border-color: #7a3050;
-}
-.sr-breadcrumb__share:focus,
-.sr-breadcrumb__share:focus-visible {
-  color: #a1a1aa;
-  outline: none;
-  box-shadow: none;
 }
 
 .sr-breadcrumb__guest-label {
@@ -943,7 +935,6 @@ watch(() => route.query, q => {
   border: 1px solid #2a2a4a;
   border-radius: 6px;
   overflow: hidden;
-  margin-left: auto;
   flex-shrink: 0;
 }
 
@@ -1113,37 +1104,35 @@ watch(() => route.query, q => {
 .sr-shortcuts-enter-from,
 .sr-shortcuts-leave-to { opacity: 0; }
 
-/* ── Mobile: Nav-Zeile als einzelne scrollbare Reihe ─────────────────────── */
+/* ── Mobile: Nav-Zeile kompakt, Breadcrumb scrollbar ─────────────────────── */
 @media (pointer: coarse) {
   .sr-nav-row {
     display: flex;
     flex-direction: row;
     align-items: center;
-    overflow-x: auto;
-    scrollbar-width: none;
     flex-shrink: 0;
     gap: 0;
   }
-  .sr-nav-row::-webkit-scrollbar { display: none; }
 
   .sr-nav-row .sr-breadcrumb {
-    flex-shrink: 0;
+    flex: 1;
+    min-width: 0;
     width: auto;
     padding: 4px 8px;
+    overflow-x: auto;
+    scrollbar-width: none;
   }
-  .sr-nav-row .sr-folders {
-    flex-shrink: 0;
-    padding: 4px 8px 4px 0;
-    border: none;
-    background: transparent;
-  }
-  .sr-breadcrumb__version { display: none; }
-  .sr-breadcrumb__mode    { display: none; }
+  .sr-nav-row .sr-breadcrumb::-webkit-scrollbar { display: none; }
 
-  /* Pfad-Segmente dürfen schrumpfen und bei Platzmangel abschneiden,
-     damit Teilen/Export immer vollständig sichtbar bleiben */
+  /* Unterordner-Pills auf Mobile ausblenden — sind im FolderPopover verfügbar */
+  .sr-nav-row .sr-folders { display: none; }
+
+  /* Utility-Cluster (Modus/Help/Version) nur Desktop */
+  .sr-breadcrumb__utility { display: none; }
+
+  /* Pfad-Segmente dürfen schrumpfen */
   .sr-breadcrumb__seg {
-    max-width: 120px;
+    max-width: 160px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -1109,7 +1109,7 @@ watch(() => route.query, q => {
 .sr-shortcuts-leave-to { opacity: 0; }
 
 /* ── Mobile: Nav-Zeile kompakt, Breadcrumb scrollbar ─────────────────────── */
-@media (pointer: coarse) {
+@media (max-width: 640px) {
   .sr-nav-row {
     display: flex;
     flex-direction: row;

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -674,13 +674,17 @@ function onAppKeydown(e) {
   e.preventDefault()
 }
 
-// Escape auf Dokument-Ebene: schließt Modals von innen nach außen, dann Auswahl
+// Escape auf Dokument-Ebene: schließt Modals von innen nach außen, dann Auswahl.
+// Muss in Capture-Phase laufen, da NC einen eigenen ESC-Handler auf document hat,
+// der sonst zuerst feuert. Modals sind per Teleport in <body> — @keydown auf
+// .sr-app greift dort nicht, deshalb reicht nur onAppKeydown nicht aus.
 function onDocKeydown(e) {
   if (e.key !== 'Escape') return
-  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } return }
-  if (showShortcuts.value)        { showShortcuts.value  = false; return }
+  const stop = () => { e.preventDefault(); e.stopPropagation(); e.stopImmediatePropagation() }
+  if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
+  if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
+  if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
+  if (showShortcuts.value)        { showShortcuts.value  = false; stop(); return }
   if (selectedIds.value.size > 0) { gridRef.value?.clearSelection?.() }
 }
 
@@ -739,7 +743,7 @@ function onVisibilityChange() {
 }
 
 onMounted(async () => {
-  document.addEventListener('keydown', onDocKeydown)
+  document.addEventListener('keydown', onDocKeydown, true)
   document.addEventListener('visibilitychange', onVisibilityChange)
   window.addEventListener('popstate', onPopState)
   startBackgroundSync()
@@ -766,7 +770,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  document.removeEventListener('keydown', onDocKeydown)
+  document.removeEventListener('keydown', onDocKeydown, true)
   document.removeEventListener('visibilitychange', onVisibilityChange)
   window.removeEventListener('popstate', onPopState)
   stopBackgroundSync()

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -680,7 +680,7 @@ function onAppKeydown(e) {
 // .sr-app greift dort nicht, deshalb reicht nur onAppKeydown nicht aus.
 function onDocKeydown(e) {
   if (e.key !== 'Escape') return
-  const stop = () => { e.preventDefault(); e.stopPropagation(); e.stopImmediatePropagation() }
+  const stop = () => { e.preventDefault(); e.stopPropagation() }
   if (showExportModal.value)      { showExportModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
   if (showShareModal.value)       { showShareModal.value = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }
   if (showShareList.value)        { showShareList.value  = false; try { document.activeElement?.blur() } catch { /* ignore */ } stop(); return }

--- a/tests/js/FilterBar.spec.js
+++ b/tests/js/FilterBar.spec.js
@@ -35,15 +35,21 @@ describe('FilterBar', () => {
     expect(w.findAll('.sr-filterbar__colordot')).toHaveLength(5)
   })
 
-  it('Status-Bereich ist versteckt wenn kein Filter aktiv', async () => {
-    const w = factory()
+  it('Status-Bereich zeigt Gesamtzahl wenn kein Filter aktiv', async () => {
+    const w = factory({ total: 42 })
     await w.vm.$nextTick()
-    expect(w.find('.sr-filterbar__status').element.style.visibility).toBe('hidden')
+    const status = w.find('.sr-filterbar__status')
+    expect(status.exists()).toBe(true)
+    expect(status.text()).toContain('42')
+    expect(status.find('.sr-filterbar__reset').exists()).toBe(false)
   })
 
-  it('Status-Bereich ist sichtbar wenn Filter aktiv', () => {
-    const w = factory({ filter: { ...defaultFilter(), minRating: 3 } })
-    expect(w.find('.sr-filterbar__status').element.style.visibility).not.toBe('hidden')
+  it('Status-Bereich zeigt "X von Y" und Reset wenn Filter aktiv', () => {
+    const w = factory({ filter: { ...defaultFilter(), minRating: 3 }, total: 42, filteredCount: 10 })
+    const status = w.find('.sr-filterbar__status')
+    expect(status.text()).toContain('10')
+    expect(status.text()).toContain('42')
+    expect(status.find('.sr-filterbar__reset').exists()).toBe(true)
   })
 
   it('zeigt Grid/Loupe Modus-Buttons', () => {

--- a/tests/js/FilterBar.spec.js
+++ b/tests/js/FilterBar.spec.js
@@ -258,4 +258,48 @@ describe('FilterBar', () => {
     expect(emitted[0][0].color).toBe('Green')
     expect(emitted[0][0].pick).toBe('pick')
   })
+
+  // ── Actions: Teilen / Export ──────────────────────────────────────────────
+
+  it('zeigt keine Actions wenn weder allowShare noch allowExport', () => {
+    const w = factory()
+    expect(w.find('[title="Freigabe-Links verwalten"]').exists()).toBe(false)
+    expect(w.find('[title="Bewertungsliste exportieren"]').exists()).toBe(false)
+  })
+
+  it('zeigt Teilen-Button wenn allowShare=true', () => {
+    const w = factory({ allowShare: true })
+    expect(w.find('[title="Freigabe-Links verwalten"]').exists()).toBe(true)
+  })
+
+  it('blendet Teilen-Button aus wenn allowShare=false, zeigt aber Export', () => {
+    const w = factory({ allowShare: false, allowExport: true, canExport: true })
+    expect(w.find('[title="Freigabe-Links verwalten"]').exists()).toBe(false)
+    expect(w.find('[title="Bewertungsliste exportieren"]').exists()).toBe(true)
+  })
+
+  it('Export-Button disabled wenn canExport=false', () => {
+    const w = factory({ allowExport: true, canExport: false })
+    const btn = w.find('[title="Bewertungsliste exportieren"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.attributes('disabled')).toBeDefined()
+  })
+
+  it('Export-Button aktiv wenn canExport=true', () => {
+    const w = factory({ allowExport: true, canExport: true })
+    const btn = w.find('[title="Bewertungsliste exportieren"]')
+    expect(btn.attributes('disabled')).toBeUndefined()
+  })
+
+  it('Klick Teilen emittiert open-share-list', async () => {
+    const w = factory({ allowShare: true })
+    await w.find('[title="Freigabe-Links verwalten"]').trigger('click')
+    expect(w.emitted('open-share-list')).toBeTruthy()
+  })
+
+  it('Klick Export emittiert open-export-modal', async () => {
+    const w = factory({ allowExport: true, canExport: true })
+    await w.find('[title="Bewertungsliste exportieren"]').trigger('click')
+    expect(w.emitted('open-export-modal')).toBeTruthy()
+  })
 })

--- a/tests/js/FolderPopover.spec.js
+++ b/tests/js/FolderPopover.spec.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import FolderPopover from '../../src/components/FolderPopover.vue'
+
+const FOLDERS = [
+  { name: 'Keeper', path: '/Shooting/Keeper' },
+  { name: 'Maybe',  path: '/Shooting/Maybe' },
+  { name: 'Ausschuss', path: '/Shooting/Ausschuss' },
+]
+
+let currentWrapper = null
+
+function factory(folders = FOLDERS) {
+  const w = mount(FolderPopover, {
+    props: { folders },
+    attachTo: document.body,
+  })
+  currentWrapper = w
+  return w
+}
+
+afterEach(() => {
+  // Sauber unmounten, damit Teleport-Inhalte entfernt werden
+  if (currentWrapper) {
+    currentWrapper.unmount()
+    currentWrapper = null
+  }
+})
+
+describe('FolderPopover', () => {
+  it('Trigger zeigt Anzahl der Ordner', () => {
+    const w = factory()
+    expect(w.find('.sr-folder-popover__trigger').text()).toContain('3')
+  })
+
+  it('Menü ist initial geschlossen', () => {
+    factory()
+    expect(document.querySelector('.sr-folder-popover__menu')).toBe(null)
+  })
+
+  it('Klick auf Trigger öffnet Menü mit allen Ordnern', async () => {
+    const w = factory()
+    await w.find('.sr-folder-popover__trigger').trigger('click')
+    await flushPromises()
+    const items = document.querySelectorAll('.sr-folder-popover__item')
+    expect(items.length).toBe(3)
+    expect(items[0].textContent).toContain('Keeper')
+    expect(items[2].textContent).toContain('Ausschuss')
+  })
+
+  it('Klick auf Item emittiert navigate + schließt Menü', async () => {
+    const w = factory()
+    await w.find('.sr-folder-popover__trigger').trigger('click')
+    await flushPromises()
+    document.querySelectorAll('.sr-folder-popover__item')[1].click()
+    await flushPromises()
+    expect(w.emitted('navigate')).toBeTruthy()
+    expect(w.emitted('navigate')[0]).toEqual(['/Shooting/Maybe'])
+    expect(document.querySelector('.sr-folder-popover__menu')).toBe(null)
+  })
+
+  it('Klick auf Catcher (Außen-Klick) schließt Menü', async () => {
+    const w = factory()
+    await w.find('.sr-folder-popover__trigger').trigger('click')
+    await flushPromises()
+    document.querySelector('.sr-folder-popover__catcher').click()
+    await flushPromises()
+    expect(document.querySelector('.sr-folder-popover__menu')).toBe(null)
+  })
+
+  it('ESC schließt Menü', async () => {
+    const w = factory()
+    await w.find('.sr-folder-popover__trigger').trigger('click')
+    await flushPromises()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await flushPromises()
+    expect(document.querySelector('.sr-folder-popover__menu')).toBe(null)
+  })
+
+  it('aria-expanded wechselt mit Offen-Zustand', async () => {
+    const w = factory()
+    const trigger = w.find('.sr-folder-popover__trigger')
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+    await trigger.trigger('click')
+    await flushPromises()
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+  })
+
+  it('Zweiter Trigger-Klick schließt Menü wieder', async () => {
+    const w = factory()
+    const trigger = w.find('.sr-folder-popover__trigger')
+    await trigger.trigger('click')
+    await flushPromises()
+    expect(document.querySelector('.sr-folder-popover__menu')).not.toBe(null)
+    await trigger.trigger('click')
+    await flushPromises()
+    expect(document.querySelector('.sr-folder-popover__menu')).toBe(null)
+  })
+})

--- a/tests/js/Gallery.spec.js
+++ b/tests/js/Gallery.spec.js
@@ -30,7 +30,8 @@ const GridViewStub = defineComponent({
 
 const stubs = {
   GridView: GridViewStub,
-  FilterBar: { template: '<div />' },
+  // FilterBar: NOT stubbed — Export/Teilen-Buttons hängen seit Plan "Ordneransicht
+  // aufräumen" in der FilterBar, Export-Tests unten prüfen sie via [title="…"]
   LoupeView: { template: '<div />' },
   SelectionBar: {
     name: 'SelectionBar',


### PR DESCRIPTION
## Summary
- Move Teilen/Export buttons from breadcrumb into FilterBar right-cluster; breadcrumb now only carries location + Mode/Help/Version utility cluster
- New `FolderPopover` component: mobile-only `[📁 N Ordner ▾]` trigger (Teleport + fixed-position menu with flip-up + viewport clamping) — desktop keeps flat folder pills
- FilterBar: image-count always visible (was hidden without active filter); readable contrast (#a1a1aa/12px); once-per-session horizontal scroll hint on mobile so users discover the scrollable filter row
- ESC reliably closes Share/Export modals (merged from #56)
- Loupe mobile footer: rating no longer clips into image, tighter row-gap, comment button padding
- Breakpoint strategy migrated from `pointer: coarse/fine` to `max-width: 640px` for layout decisions (handles touch-laptops); `pointer: fine` retained only to suppress hover-stickiness on touch

## Chore
- Stop tracking Vite-generated CSS bundles (`starrate-{main,guest,settings}.css`) — chunk-hashed, rebuilt per deploy
- Renamed shadowed `const n` in `FolderPopover.focusItem` (previously masked imported l10n `n()`)
- FilterBar scroll-hint guarded against jsdom stub

## Tests
- 340 Vitest tests passing (12 new: FolderPopover, FilterBar actions, status refactor)
- No CSS/DOM regressions on donkeykong (NC33) and sixpack (production)

## Test plan
- [x] `npm run test` green
- [x] Desktop: filter bar shows Teilen/Export; folder pills as own row; breadcrumb utility cluster aligned right
- [x] Mobile (375×667): breadcrumb has `[📁 N Ordner ▾]` trigger; popover flips up when near bottom; filter row shows subtle scroll wiggle on first visit per session
- [x] Guest mode: Teilen hidden; Export only when share allows it
- [x] ESC closes Share & Export modals