### PR TITLE
test: NodeDeletedListener coverage

### DIFF
--- a/tests/Unit/Listener/NodeDeletedListenerTest.php
+++ b/tests/Unit/Listener/NodeDeletedListenerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\StarRate\Tests\Unit\Listener;
+
+use OCA\StarRate\Listener\NodeDeletedListener;
+use OCA\StarRate\Service\ShareService;
+use OCP\EventDispatcher\Event;
+use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Node;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NodeDeletedListenerTest extends TestCase
+{
+    /** @var ShareService&MockObject */
+    private ShareService $shareService;
+    private NodeDeletedListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->shareService = $this->createMock(ShareService::class);
+        $this->listener     = new NodeDeletedListener($this->shareService);
+    }
+
+    public function testDeletesCommentForFileId(): void
+    {
+        $node = $this->createMock(Node::class);
+        $node->method('getId')->willReturn(4711);
+
+        $event = $this->createMock(NodeDeletedEvent::class);
+        $event->method('getNode')->willReturn($node);
+
+        $this->shareService
+            ->expects($this->once())
+            ->method('deleteComment')
+            ->with(4711);
+
+        $this->listener->handle($event);
+    }
+
+    public function testIgnoresUnrelatedEvents(): void
+    {
+        $event = $this->createMock(Event::class);
+
+        $this->shareService
+            ->expects($this->never())
+            ->method('deleteComment');
+
+        $this->listener->handle($event);
+    }
+
+    public function testIgnoresNodeWithoutId(): void
+    {
+        $node = $this->createMock(Node::class);
+        $node->method('getId')->willReturn(null);
+
+        $event = $this->createMock(NodeDeletedEvent::class);
+        $event->method('getNode')->willReturn($node);
+
+        $this->shareService
+            ->expects($this->never())
+            ->method('deleteComment');
+
+        $this->listener->handle($event);
+    }
+
+    public function testPassesThroughArbitraryFileIds(): void
+    {
+        foreach ([1, 9999999] as $fileId) {
+            $service = $this->createMock(ShareService::class);
+            $service->expects($this->once())
+                ->method('deleteComment')
+                ->with($fileId);
+
+            $node = $this->createMock(Node::class);
+            $node->method('getId')->willReturn($fileId);
+            $event = $this->createMock(NodeDeletedEvent::class);
+            $event->method('getNode')->willReturn($node);
+
+            (new NodeDeletedListener($service))->handle($event);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds PHPUnit tests for `NodeDeletedListener`, which deletes StarRate comments when the underlying file is removed. The listener was previously uncovered.

Covers:
- Normal path: `NodeDeletedEvent` with valid `fileId` → `ShareService::deleteComment($fileId)` is called once.
- Foreign events (not `NodeDeletedEvent`) are ignored — no call.
- Nodes with `getId() === null` are ignored — no call.
- Arbitrary file ids (smallest, large) are passed through unchanged.

## Why
Nextcloud recycles file ids. Without this listener, a newly uploaded photo could inherit the comment of a previously deleted file. The logic is small but security-adjacent; adding direct tests so future refactors don't silently break it.

## Test plan
- [ ] CI green (PHP 8.1 + 8.3)