### PR TITLE
feat: guest login events in share log

### DIFF
--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -276,6 +276,14 @@ class ShareController extends Controller
             return new DataResponse(['error' => 'Password required'], Http::STATUS_UNAUTHORIZED);
         }
 
+        // Login-Event: einmal pro Session loggen (deckt pw-Shares UND offene Shares ab)
+        $session = \OC::$server->getSession();
+        $sessionKey = "starrate_share_{$token}_logged";
+        if (!$session->get($sessionKey)) {
+            $this->shareService->appendLoginToLog($share);
+            $session->set($sessionKey, true);
+        }
+
         $subPath = (string) ($this->request->getParam('path', ''));
 
         try {
@@ -439,6 +447,7 @@ class ShareController extends Controller
         }
 
         $this->logger->warning("StarRate guest password failed: token={$token} ip={$this->request->getRemoteAddress()}");
+        $this->shareService->appendLoginFailedToLog($share);
         return new DataResponse(['error' => 'Wrong password'], Http::STATUS_UNAUTHORIZED);
     }
 

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -584,6 +584,31 @@ class ShareService
     }
 
     /**
+     * Schreibt einen Login-Erfolgs-Eintrag (erstes Öffnen pro Session).
+     */
+    public function appendLoginToLog(array $share): void
+    {
+        $this->appendToLog($share['owner_id'], $share['token'], [
+            'event'      => 'login',
+            'guest_name' => $share['guest_name'] ?? '',
+            'timestamp'  => time(),
+        ]);
+    }
+
+    /**
+     * Schreibt einen Fehlversuch-Eintrag (falsches Passwort).
+     * Kein guest_name — der Share ist per Definition an einen Namen gebunden,
+     * der Fehlversuch kommt von jemandem, der das Passwort nicht kennt.
+     */
+    public function appendLoginFailedToLog(array $share): void
+    {
+        $this->appendToLog($share['owner_id'], $share['token'], [
+            'event'     => 'login_failed',
+            'timestamp' => time(),
+        ]);
+    }
+
+    /**
      * Löscht den Kommentar zu einer Datei (auch beim File-Delete aufgerufen).
      */
     public function deleteComment(int $fileId): void

--- a/src/components/ShareList.vue
+++ b/src/components/ShareList.vue
@@ -197,28 +197,46 @@
                 {{ t('starrate', 'Noch keine Bewertungen über diesen Link.') }}
               </div>
               <div v-else class="sr-share-list__log-entries">
-                <div
-                  v-for="(entry, i) in logs[share.token]"
-                  :key="i"
-                  class="sr-share-list__log-entry"
-                >
-                  <span class="sr-share-list__log-name">{{ entry.guest_name }}</span>
-                  <span class="sr-share-list__log-rating">
-                    {{ entry.rating !== null
-                        ? '★'.repeat(entry.rating) + '☆'.repeat(5 - (entry.rating ?? 0))
-                        : (entry.pick && entry.pick !== 'none' ? '' : '–') }}
-                  </span>
-                  <span v-if="entry.color" class="sr-share-list__log-color" :class="`sr-share-list__log-color--${entry.color.toLowerCase()}`">
-                    ●
-                  </span>
-                  <span
-                    v-if="entry.pick && entry.pick !== 'none'"
-                    class="sr-share-list__log-pick"
-                    :class="`sr-share-list__log-pick--${entry.pick}`"
-                  >{{ entry.pick === 'pick' ? '✓' : '⊘' }}</span>
-                  <span class="sr-share-list__log-file">{{ entry.filename ?? `#${entry.file_id}` }}</span>
-                  <span class="sr-share-list__log-time">{{ formatDateTime(entry.timestamp) }}</span>
-                </div>
+                <template v-for="(entry, i) in logs[share.token]" :key="i">
+                  <!-- Login / Login-Fehlversuch -->
+                  <div
+                    v-if="entry.event === 'login' || entry.event === 'login_failed'"
+                    class="sr-share-list__log-entry sr-share-list__log-entry--event"
+                    :class="`sr-share-list__log-entry--${entry.event}`"
+                  >
+                    <span class="sr-share-list__log-icon" aria-hidden="true">
+                      {{ entry.event === 'login' ? '🔓' : '🔒' }}
+                    </span>
+                    <span class="sr-share-list__log-text">
+                      <template v-if="entry.event === 'login'">
+                        {{ t('starrate', '{name} hat sich angemeldet', { name: entry.guest_name || t('starrate', 'Gast') }) }}
+                      </template>
+                      <template v-else>
+                        {{ t('starrate', 'Passwort falsch') }}
+                      </template>
+                    </span>
+                    <span class="sr-share-list__log-time">{{ formatDateTime(entry.timestamp) }}</span>
+                  </div>
+                  <!-- Bewertung / Kommentar -->
+                  <div v-else class="sr-share-list__log-entry">
+                    <span class="sr-share-list__log-name">{{ entry.guest_name }}</span>
+                    <span class="sr-share-list__log-rating">
+                      {{ entry.rating !== null
+                          ? '★'.repeat(entry.rating) + '☆'.repeat(5 - (entry.rating ?? 0))
+                          : (entry.pick && entry.pick !== 'none' ? '' : '–') }}
+                    </span>
+                    <span v-if="entry.color" class="sr-share-list__log-color" :class="`sr-share-list__log-color--${entry.color.toLowerCase()}`">
+                      ●
+                    </span>
+                    <span
+                      v-if="entry.pick && entry.pick !== 'none'"
+                      class="sr-share-list__log-pick"
+                      :class="`sr-share-list__log-pick--${entry.pick}`"
+                    >{{ entry.pick === 'pick' ? '✓' : '⊘' }}</span>
+                    <span class="sr-share-list__log-file">{{ entry.filename ?? `#${entry.file_id}` }}</span>
+                    <span class="sr-share-list__log-time">{{ formatDateTime(entry.timestamp) }}</span>
+                  </div>
+                </template>
               </div>
             </div>
 
@@ -707,6 +725,15 @@ defineExpose({ loadShares })
   font-size: 0.8rem;
 }
 .sr-share-list__log-entry:last-child { border-bottom: none; }
+.sr-share-list__log-entry--event {
+  color: #a1a1aa;
+  font-style: italic;
+}
+.sr-share-list__log-entry--login_failed {
+  color: #e94560;
+}
+.sr-share-list__log-icon { flex-shrink: 0; }
+.sr-share-list__log-text { flex: 1; }
 .sr-share-list__log-name {
   color: #d4d4d8;
   font-weight: 500;

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -475,6 +475,90 @@ class ShareServiceTest extends TestCase
         $this->service->deleteComment(42);
     }
 
+    // ─── Tests: Login-Log-Events ──────────────────────────────────────────────
+
+    public function testAppendLoginToLogStoresEventWithGuestName(): void
+    {
+        $share = [
+            'owner_id'   => self::OWNER_ID,
+            'token'      => self::SAMPLE_TOKEN,
+            'guest_name' => 'Anna',
+        ];
+
+        $saved = null;
+        $this->config->method('getUserValue')->willReturn('[]');
+        $this->config->method('setUserValue')
+            ->willReturnCallback(function ($u, $a, $k, $v) use (&$saved) { $saved = json_decode($v, true); });
+
+        $this->service->appendLoginToLog($share);
+
+        $this->assertCount(1, $saved);
+        $this->assertSame('login', $saved[0]['event']);
+        $this->assertSame('Anna', $saved[0]['guest_name']);
+        $this->assertIsInt($saved[0]['timestamp']);
+    }
+
+    public function testAppendLoginToLogHandlesMissingGuestName(): void
+    {
+        $share = ['owner_id' => self::OWNER_ID, 'token' => self::SAMPLE_TOKEN];
+
+        $saved = null;
+        $this->config->method('getUserValue')->willReturn('[]');
+        $this->config->method('setUserValue')
+            ->willReturnCallback(function ($u, $a, $k, $v) use (&$saved) { $saved = json_decode($v, true); });
+
+        $this->service->appendLoginToLog($share);
+
+        $this->assertSame('login', $saved[0]['event']);
+        $this->assertSame('', $saved[0]['guest_name']);
+    }
+
+    public function testAppendLoginFailedToLogOmitsGuestName(): void
+    {
+        $share = [
+            'owner_id'   => self::OWNER_ID,
+            'token'      => self::SAMPLE_TOKEN,
+            'guest_name' => 'Anna',
+        ];
+
+        $saved = null;
+        $this->config->method('getUserValue')->willReturn('[]');
+        $this->config->method('setUserValue')
+            ->willReturnCallback(function ($u, $a, $k, $v) use (&$saved) { $saved = json_decode($v, true); });
+
+        $this->service->appendLoginFailedToLog($share);
+
+        $this->assertCount(1, $saved);
+        $this->assertSame('login_failed', $saved[0]['event']);
+        $this->assertArrayNotHasKey('guest_name', $saved[0]);
+        $this->assertIsInt($saved[0]['timestamp']);
+    }
+
+    public function testLoginEventsShareRingBufferLimit(): void
+    {
+        $share = [
+            'owner_id'   => self::OWNER_ID,
+            'token'      => self::SAMPLE_TOKEN,
+            'guest_name' => 'Anna',
+        ];
+
+        $existingLog = [];
+        for ($i = 0; $i < 500; $i++) {
+            $existingLog[] = ['file_id' => $i, 'rating' => 1, 'color' => null, 'pick' => null, 'guest_name' => 'Bot', 'timestamp' => $i + 1];
+        }
+
+        $saved = null;
+        $this->config->method('getUserValue')->willReturn(json_encode($existingLog));
+        $this->config->method('setUserValue')
+            ->willReturnCallback(function ($u, $a, $k, $v) use (&$saved) { $saved = json_decode($v, true); });
+
+        $this->service->appendLoginToLog($share);
+
+        $this->assertCount(500, $saved);
+        $this->assertSame('login', $saved[499]['event']);
+        $this->assertNotSame(0, $saved[0]['file_id']);
+    }
+
     // ─── Tests: Guest-Log-Trimming ────────────────────────────────────────────
 
     public function testGuestLogTrimmedTo500Entries(): void


### PR DESCRIPTION
## Summary
Extends the existing per-share guest log with login events so owners can see when a guest opens their share link and whether anyone fails the password check.

- `appendLoginToLog(share)` — event `login`, once per session via `guestImages`, covers both password-protected and open shares
- `appendLoginFailedToLog(share)` — event `login_failed` on wrong password, no guest_name (the share is bound to a name; a failed attempt is by someone who doesn't know the password)
- `ShareList.vue` renders event entries as their own line (🔓 login / 🔒 failed), failures highlighted red
- Events share the existing 500-entry ring buffer with ratings/comments — not an anti-abuse feature

## Rationale
Owners want visibility into who's actually looking at a share (including repeat visits) and whether brute-force attempts happen. Session-based logging avoids one-entry-per-request spam; it logs once per fresh browser session.

## Test plan
- [x] `php vendor/bin/phpunit` — 255 passing (4 new tests for login events)
- [x] `npm run test` — 325 passing
- [ ] Manual: open a password-share → log shows 🔓 entry; refresh → no duplicate; wrong password → 🔒 entry; open unprotected share → 🔓 entry