### PR TITLE
fix: Grid scroll no longer animates when returning from Loupe

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -500,19 +500,22 @@ function columnsEstimate() {
   return Math.max(1, Math.floor(gridEl.value.offsetWidth / THUMB_SIZE))
 }
 
-function scrollItemIntoView(index) {
+function scrollItemIntoView(index, behavior = 'smooth') {
   nextTick(() => {
     const el = gridEl.value?.querySelector(`[data-index="${index}"]`)
-    el?.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' })
+    el?.scrollIntoView?.({ block: 'nearest', behavior })
   })
 }
 
 // ─── Sync mit Lupenansicht ────────────────────────────────────────────────────
 
+let firstScrollSync = true
 watch(() => props.currentIndex, idx => {
   if (idx >= 0) {
     focusedIndex.value = idx
-    scrollItemIntoView(idx)
+    // Erster Sync (Mount / Loupe→Grid): sofort, nicht animiert. Sonst smooth.
+    scrollItemIntoView(idx, firstScrollSync ? 'auto' : 'smooth')
+    firstScrollSync = false
   }
 }, { immediate: true })   // immediate: focusedIndex beim Mount sofort setzen
 


### PR DESCRIPTION
## Summary
- Fixes visible scroll animation from top → target position when switching Loupe → Grid
- First sync (mount / remount) now uses `behavior: 'auto'`, subsequent syncs stay `'smooth'` for keyboard nav

## Root cause
`watch(() => props.currentIndex, ..., { immediate: true })` fires on Grid remount after Loupe. With `behavior: 'smooth'`, the browser visibly scrolled the newly-mounted grid from y=0 to the target item instead of landing there directly.

## Test plan
- [ ] Scroll to image ~100 in a large folder
- [ ] Click Loupe → Grid toggle
- [ ] Grid appears already scrolled to image 100 (no visible animation)
- [ ] Arrow-key navigation still smooth-scrolls