### PR TITLE
Fix guest footer overlapping images on public share pages (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.2.10
+
+### EN
+
+**Bug fixes**
+- **Guest share: Nextcloud footer no longer overlaps images** (#62) — on public share pages NC renders an entity-name/legal/signup footer that on mobile could eat up to 1/3 of the viewport and on desktop pushed the grid up. The StarRate guest view now renders as a full-viewport overlay and hides NC's header/footer chrome (imprint/privacy remain reachable via the NC instance root). Big thanks to @matt-ek for the detailed repro and @lukegraphix for the independent reproduction on a fresh install.
+
+### DE
+
+**Bugfixes**
+- **Gast-Freigabe: Nextcloud-Footer überlagert keine Bilder mehr** (#62) — auf Public-Share-Seiten rendert NC einen Footer mit Entity-Name, Legal-Links und Signup-Promo, der auf Mobile bis zu 1/3 des Viewports fressen konnte und auf Desktop das Grid hochgedrückt hat. Die StarRate-Gast-Ansicht legt sich jetzt als Vollbild-Overlay über die Seite und blendet NC-Header und -Footer aus (Impressum/Datenschutz bleiben über den Root der NC-Instanz erreichbar). Großer Dank an @matt-ek für die detaillierte Repro und @lukegraphix für die unabhängige Reproduktion auf einer frischen Installation.
+
 ## 1.2.9
 
 ### EN

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -50,7 +50,7 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 - Englisch und Deutsch
     ]]></description>
 
-    <version>1.2.9</version>
+    <version>1.2.10</version>
     <licence>agpl</licence>
 
     <author mail="starrate@merlin1.de" homepage="https://github.com/merlin1de/starrate">

--- a/css/starrate.css
+++ b/css/starrate.css
@@ -56,6 +56,31 @@
   overflow: hidden;
 }
 
+/* ── Guest Mode Layout Fix (Issue #62) ──────────────────────────────────── */
+/* NC 33 PublicTemplateResponse rendert <footer class="guest-box"> als Sibling
+   von #content – mit Entity-Name, Legal-Links und "Get your own Nextcloud"-
+   Promo. Auf Mobile frisst das bis zu 1/3 des Viewports und bricht das Full-
+   Screen-Culling-UX. Lösung: App-Root als Full-Viewport-Overlay positionieren
+   und den Footer komplett ausblenden (Impressum bleibt anderweitig auf der
+   NC-Instanz erreichbar, Signup-Promo ist im Culling-Kontext irrelevant). */
+
+body#body-public {
+  overflow: hidden;
+}
+
+body#body-public #starrate-guest-root {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 100;
+  background: var(--sr-bg);
+}
+
+body#body-public .guest-box {
+  display: none;
+}
+
 /* ── Kritische Layout-Regeln (FOUC-Schutz) ────────────────────────────────── */
 /* Diese Regeln liegen sonst in den async geladenen Gallery/FilterBar-Chunks.
    Ohne sie kollabieren Nav-Row + FilterBar beim ersten Loupe-Einstieg auf 0px,

--- a/css/starrate.css
+++ b/css/starrate.css
@@ -57,12 +57,15 @@
 }
 
 /* ── Guest Mode Layout Fix (Issue #62) ──────────────────────────────────── */
-/* NC 33 PublicTemplateResponse rendert <footer class="guest-box"> als Sibling
-   von #content – mit Entity-Name, Legal-Links und "Get your own Nextcloud"-
-   Promo. Auf Mobile frisst das bis zu 1/3 des Viewports und bricht das Full-
-   Screen-Culling-UX. Lösung: App-Root als Full-Viewport-Overlay positionieren
-   und den Footer komplett ausblenden (Impressum bleibt anderweitig auf der
-   NC-Instanz erreichbar, Signup-Promo ist im Culling-Kontext irrelevant). */
+/* NC 33 PublicTemplateResponse rendert um #content herum einen NC-Header
+   (<header id="header"> mit Apps-Menü/Entity-Name) und einen NC-Footer
+   (<footer class="guest-box"> mit Legal-Links + "Get your own Nextcloud"-
+   Signup-Promo). Auf Mobile frisst der Footer bis zu 1/3 des Viewports,
+   der Header verschluckt weitere 50px – das bricht das Full-Screen-Culling-
+   UX. Lösung: App-Root als Full-Viewport-Overlay, NC-Header/-Footer
+   komplett ausblenden (Impressum bleibt anderweitig auf der NC-Instanz
+   erreichbar, Apps-Menü/Signup-Promo sind im Guest-Culling-Kontext
+   irrelevant – analog zum Vollbild-Viewer von NC Photos/Files). */
 
 body#body-public {
   overflow: hidden;
@@ -77,6 +80,7 @@ body#body-public #starrate-guest-root {
   background: var(--sr-bg);
 }
 
+body#body-public #header,
 body#body-public .guest-box {
   display: none;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starrate",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starrate",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/event-bus": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrate",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "type": "module",
   "description": "Professionelles Foto-Bewertungs- und Lightroom-Sync-Tool für Nextcloud",
   "scripts": {


### PR DESCRIPTION
## Summary

- NC 33's `PublicTemplateResponse` renders a `<footer class="guest-box">` sibling to `#content` containing the entity name, legal links, and a "Get your own Nextcloud" signup promo.
- On mobile this consumes up to 1/3 of the viewport; on desktop it breaks full-screen culling by pushing the grid up and leaving a white card at the bottom.
- Fix: position the StarRate guest app root as a full-viewport overlay (`position: fixed; inset: 0; z-index: 100`) and hide the footer via `display: none`. The imprint remains reachable elsewhere on the NC instance, and the signup promo is irrelevant inside a photo-culling flow.

Closes #62

## Test plan

- [x] Repro confirmed on donkeykong NC33-nightly (share token `87b95514...`): footer visible below grid before fix
- [x] CSS rule present in deployed `Gallery-*.chunk.css` on nc-nightly4
- [x] Guest page HTML references the updated bundled entry point
- [ ] Visual check in desktop browser: full-viewport grid, no footer band
- [ ] Visual check on mobile viewport (DevTools 375×667): grid fills the screen
- [ ] Smoke: logged-in main app layout unaffected (rules scoped to `body#body-public`)