### PR TITLE
Per-folder memory + per-share recursive (v1.3.1)

### DIFF
--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -73,6 +73,8 @@ class ShareController extends Controller
                 !empty($body['allow_pick']),
                 !empty($body['allow_export']),
                 !empty($body['allow_comment']),
+                !empty($body['recursive']),
+                isset($body['depth']) ? (int) $body['depth'] : 0,
             );
             return new DataResponse(['share' => $share], Http::STATUS_CREATED);
         } catch (\InvalidArgumentException $e) {
@@ -597,6 +599,13 @@ class ShareController extends Controller
             && !in_array($body['permissions'], [ShareService::PERM_VIEW, ShareService::PERM_RATE], true)
         ) {
             $errors[] = 'permissions muss "view" oder "rate" sein';
+        }
+
+        if (isset($body['depth'])) {
+            $d = (int) $body['depth'];
+            if ($d < 0 || $d > 4) {
+                $errors[] = 'depth muss zwischen 0 und 4 liegen';
+            }
         }
 
         return $errors;

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -136,9 +136,13 @@ class ShareController extends Controller
         if ($auth instanceof DataResponse) return $auth;
         $userId = $auth;
 
-        $body  = $this->getJsonBody();
-        $share = $this->shareService->getShare($token);
+        $body   = $this->getJsonBody();
+        $errors = $this->validateShareBody($body, false);  // false = update, nc_path optional
+        if (!empty($errors)) {
+            return new DataResponse(['error' => implode('; ', $errors)], Http::STATUS_UNPROCESSABLE_ENTITY);
+        }
 
+        $share = $this->shareService->getShare($token);
         if ($share === null || $share['owner_id'] !== $userId) {
             return new DataResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
         }
@@ -576,11 +580,18 @@ class ShareController extends Controller
         return false;
     }
 
-    private function validateShareBody(array $body): array
+    /**
+     * Validiert den Share-Body. Wird sowohl von create als auch update genutzt.
+     *
+     * @param bool $isCreate true beim Anlegen — nc_path ist Pflicht.
+     *                       false beim Update — nc_path ist optional (nur prüfen
+     *                       wenn vorhanden, weil Updates nur Teilfelder ändern).
+     */
+    private function validateShareBody(array $body, bool $isCreate = true): array
     {
         $errors = [];
 
-        if (empty($body['nc_path'])) {
+        if ($isCreate && empty($body['nc_path'])) {
             $errors[] = 'nc_path ist erforderlich';
         }
 

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -65,6 +65,8 @@ class ShareService
         bool    $allowPick = false,
         bool    $allowExport = false,
         bool    $allowComment = false,
+        bool    $recursive = false,
+        int     $depth = 0,
     ): array {
         $this->validatePermissions($permissions);
 
@@ -85,6 +87,8 @@ class ShareService
             'allow_pick'    => $allowPick,
             'allow_export'  => $allowExport,
             'allow_comment' => $allowComment,
+            'recursive'     => $recursive,
+            'depth'         => max(0, min(4, $depth)),
             'created_at'    => time(),
             'active'        => true,
         ];
@@ -180,6 +184,15 @@ class ShareService
         if (isset($data['allow_comment'])) {
             $all[$token]['allow_comment'] = (bool) $data['allow_comment'];
         }
+        if (isset($data['recursive'])) {
+            $all[$token]['recursive'] = (bool) $data['recursive'];
+        }
+        if (isset($data['depth'])) {
+            $all[$token]['depth'] = max(0, min(4, (int) $data['depth']));
+        }
+        if (isset($data['nc_path'])) {
+            $all[$token]['nc_path'] = rtrim((string) $data['nc_path'], '/');
+        }
 
         $this->saveShares($ownerId, $all);
 
@@ -245,45 +258,65 @@ class ShareService
         $ownerId   = $share['owner_id'];
         $ncPath    = rtrim($share['nc_path'], '/');
         $minRating = (int) ($share['min_rating'] ?? 0);
-
-        // Subpath bereinigen (Traversal-Schutz)
-        $subPath = $this->sanitizeSubPath($subPath);
+        $recursive = (bool) ($share['recursive'] ?? false);
+        $depth     = max(0, min(4, (int) ($share['depth'] ?? 0)));
 
         $userFolder = $this->rootFolder->getUserFolder($ownerId);
-        $fullPath   = $ncPath . $subPath;
-        $folder     = $fullPath === '' || $fullPath === '/'
-            ? $userFolder
-            : $userFolder->get(ltrim($fullPath, '/'));
 
-        if (!($folder instanceof Folder)) {
-            throw new \RuntimeException("Pfad ist kein Ordner: {$fullPath}");
-        }
+        if ($recursive) {
+            // Bei recursive=true ignorieren wir den subPath konsequent — der
+            // Gast bekommt immer den gesamten Subtree ab dem Share-Root, ohne
+            // Folder-Drill. Das verhindert unbeabsichtigtes Erschleichen von
+            // Subfolder-Listings durch URL-Manipulation.
+            $folder = $ncPath === '' || $ncPath === '/'
+                ? $userFolder
+                : $userFolder->get(ltrim($ncPath, '/'));
 
-        $images  = [];
-        $folders = [];
+            if (!($folder instanceof Folder)) {
+                throw new \RuntimeException("Pfad ist kein Ordner: {$ncPath}");
+            }
 
-        foreach ($folder->getDirectoryListing() as $node) {
-            if ($node instanceof Folder) {
-                if ($node->getName()[0] === '.') continue;
-                $relPath   = $subPath . '/' . $node->getName();
-                $folders[] = [
-                    'name' => $node->getName(),
-                    'path' => $relPath,
+            $images = $this->listImagesRecursiveForShare($folder, $depth);
+            // Bei recursive: kein Folder-Listing, der Gast hat keine Navigation
+            $folders = [];
+        } else {
+            // Subpath bereinigen (Traversal-Schutz) — gilt nur im Nicht-Recursive-Modus
+            $subPath = $this->sanitizeSubPath($subPath);
+            $fullPath = $ncPath . $subPath;
+            $folder = $fullPath === '' || $fullPath === '/'
+                ? $userFolder
+                : $userFolder->get(ltrim($fullPath, '/'));
+
+            if (!($folder instanceof Folder)) {
+                throw new \RuntimeException("Pfad ist kein Ordner: {$fullPath}");
+            }
+
+            $images  = [];
+            $folders = [];
+
+            foreach ($folder->getDirectoryListing() as $node) {
+                if ($node instanceof Folder) {
+                    if ($node->getName()[0] === '.') continue;
+                    $relPath   = $subPath . '/' . $node->getName();
+                    $folders[] = [
+                        'name' => $node->getName(),
+                        'path' => $relPath,
+                    ];
+                    continue;
+                }
+                if (!($node instanceof File)) {
+                    continue;
+                }
+                if (!in_array($node->getMimeType(), self::GUEST_MIME, true)) {
+                    continue;
+                }
+                $images[] = [
+                    'id'    => $node->getId(),
+                    'name'  => $node->getName(),
+                    'mtime' => $node->getMtime(),
+                    'size'  => $node->getSize(),
                 ];
-                continue;
             }
-            if (!($node instanceof File)) {
-                continue;
-            }
-            if (!in_array($node->getMimeType(), self::GUEST_MIME, true)) {
-                continue;
-            }
-            $images[] = [
-                'id'    => $node->getId(),
-                'name'  => $node->getName(),
-                'mtime' => $node->getMtime(),
-                'size'  => $node->getSize(),
-            ];
         }
 
         if (!empty($images)) {
@@ -702,5 +735,88 @@ class ShareService
                 "Ungültige Berechtigung: {$permissions}. Erlaubt: view, rate"
             );
         }
+    }
+
+    /**
+     * !!! SECURITY-KRITISCHE DUPLIKATION mit GalleryController::listImagesRecursiveFromDb.
+     *
+     * Beide Methoden müssen exakt gleich filtern (Storage-Scope, Hidden-Folder,
+     * MIME-Whitelist, Hard-Limit). Wenn sie auseinanderdriften, riskieren wir,
+     * dass ein Gast mehr Dateien zu sehen bekommt als der Owner sich beim
+     * Anlegen des Shares vorstellt — z.B. Hidden-NC-Verzeichnisse oder
+     * Mounts aus anderen Storages.
+     *
+     * Bewusste Code-Doppelung statt Service-Extraction für V1.3.1: bei jeder
+     * Änderung an einer Stelle MUSS die andere mit angepasst werden, und der
+     * Diff fällt im Review auf. Ein versehentliches "nur am Owner-Pfad
+     * gefixt"-Refactor ist hier gefährlicher als die paar Zeilen Doppelung.
+     *
+     * Refactor-TODO: irgendwann nach 1.3.1 in einen ImageListingService
+     * extrahieren, mit Tests die beide Aufrufer gegen exakt gleiche
+     * Erwartungen prüfen.
+     *
+     * Limit für Guest 25k wie beim Owner — verhindert Memory-Explosion bei
+     * recursive=true auf großen Trees.
+     */
+    private function listImagesRecursiveForShare(Folder $folder, int $depth): array
+    {
+        $RECURSIVE_HARD_LIMIT = 25000;
+
+        $storageId    = $folder->getStorage()->getCache()->getNumericStorageId();
+        $internalPath = $folder->getInternalPath();
+        $pathPrefix   = ($internalPath === '' ? '' : $internalPath . '/') . '%';
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('fc.fileid', 'fc.name', 'fc.path', 'fc.size', 'fc.mtime', 'mt.mimetype')
+            ->from('filecache', 'fc')
+            ->innerJoin('fc', 'mimetypes', 'mt', $qb->expr()->eq('mt.id', 'fc.mimetype'))
+            ->where($qb->expr()->eq('fc.storage', $qb->createNamedParameter($storageId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)))
+            ->andWhere($qb->expr()->like('fc.path', $qb->createNamedParameter($pathPrefix)))
+            ->andWhere($qb->expr()->in('mt.mimetype', $qb->createNamedParameter(self::GUEST_MIME, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_STR_ARRAY)))
+            // Hidden-Pfade ausschließen — sicherheitskritisch
+            ->andWhere($qb->expr()->notLike('fc.path', $qb->createNamedParameter('%/.%')))
+            ->setMaxResults($RECURSIVE_HARD_LIMIT);
+
+        $result = $qb->executeQuery();
+        $rows = $result->fetchAll();
+        $result->closeCursor();
+
+        $rootInternalPrefix = $internalPath === '' ? 'files' : $internalPath;
+
+        $images = [];
+        foreach ($rows as $row) {
+            $internalRelative = ltrim(substr($row['path'], strlen($rootInternalPrefix)), '/');
+            $images[] = [
+                'id'       => (int) $row['fileid'],
+                'name'     => $row['name'],
+                'relPath'  => $internalRelative,
+                'size'     => (int) $row['size'],
+                'mtime'    => (int) $row['mtime'],
+                'groupKey' => $depth > 0 ? self::pathPrefix($internalRelative, $depth) : '',
+            ];
+        }
+
+        // Sortierung: groupKey + name (analog Owner-Ansicht)
+        usort($images, function (array $a, array $b): int {
+            $cmp = $a['groupKey'] !== '' || $b['groupKey'] !== ''
+                ? strcasecmp($a['groupKey'], $b['groupKey'])
+                : 0;
+            if ($cmp !== 0) return $cmp;
+            return strcasecmp($a['name'], $b['name']);
+        });
+
+        return array_values($images);
+    }
+
+    /**
+     * Liefert die ersten N '/'-Segmente eines Pfads (ohne Dateiname).
+     * Spiegelt GalleryController::pathPrefix.
+     */
+    private static function pathPrefix(string $relPath, int $depth): string
+    {
+        $segments = explode('/', $relPath);
+        array_pop($segments);
+        if ($segments === []) return '';
+        return implode('/', array_slice($segments, 0, $depth));
     }
 }

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -376,7 +376,12 @@ class ShareService
         $response = new FileDisplayResponse($preview, 200, [
             'Content-Type' => $preview->getMimeType(),
         ]);
-        $response->cacheFor(3600);
+        // 7 Tage Browser-Cache. Hilft beim Wiederbesuch derselben Gast-Galerie
+        // (zweite Bewertungsrunde, andere Endgeräte vom selben Empfänger).
+        // FileDisplayResponse setzt ETag automatisch — Browser kann nach Ablauf
+        // per If-None-Match revalidieren, Server liefert 304 wenn unverändert.
+        // private (Default), nicht immutable → bei mtime-Änderung neu geladen.
+        $response->cacheFor(60 * 60 * 24 * 7);
         return $response;
     }
 

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -372,7 +372,13 @@ class ShareService
         $height = min(max($height, 32), 2160);
 
         $crop     = ($width <= 800);  // Thumbnails: crop; Previews: kein Crop
-        $preview  = $this->previewManager->getPreview($file, $width, $height, $crop);
+        // Mode COVER bei Thumbs explizit setzen: das Owner-Frontend nutzt
+        // /core/preview?mode=cover, NC cached die Datei unter MODE_COVER.
+        // Ohne den expliziten Mode würde getPreview() auf MODE_FILL fallen
+        // → andere Cache-Datei → komplette Neugenerierung beim ersten
+        // Gast-Besuch. Für Previews (kein Crop) bleibt der Default.
+        $mode     = $crop ? IPreviewManager::MODE_COVER : IPreviewManager::MODE_FILL;
+        $preview  = $this->previewManager->getPreview($file, $width, $height, $crop, $mode);
         $response = new FileDisplayResponse($preview, 200, [
             'Content-Type' => $preview->getMimeType(),
         ]);

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -372,13 +372,7 @@ class ShareService
         $height = min(max($height, 32), 2160);
 
         $crop     = ($width <= 800);  // Thumbnails: crop; Previews: kein Crop
-        // Mode COVER bei Thumbs explizit setzen: das Owner-Frontend nutzt
-        // /core/preview?mode=cover, NC cached die Datei unter MODE_COVER.
-        // Ohne den expliziten Mode würde getPreview() auf MODE_FILL fallen
-        // → andere Cache-Datei → komplette Neugenerierung beim ersten
-        // Gast-Besuch. Für Previews (kein Crop) bleibt der Default.
-        $mode     = $crop ? IPreviewManager::MODE_COVER : IPreviewManager::MODE_FILL;
-        $preview  = $this->previewManager->getPreview($file, $width, $height, $crop, $mode);
+        $preview  = $this->previewManager->getPreview($file, $width, $height, $crop);
         $response = new FileDisplayResponse($preview, 200, [
             'Content-Type' => $preview->getMimeType(),
         ]);

--- a/src/components/ShareList.vue
+++ b/src/components/ShareList.vue
@@ -43,31 +43,33 @@
                   <span v-if="share.min_rating > 0" class="sr-share-list__badge sr-share-list__badge--filter">
                     ≥ {{ share.min_rating }} ★
                   </span>
+                  <!-- Read-only Status-Indikatoren — nur sichtbar wenn aktiv. Konfiguration
+                       erfolgt im Edit-Modal (Stift-Button rechts). -->
                   <span
                     v-if="share.has_password"
-                    class="sr-share-list__badge sr-share-list__badge--pw sr-share-list__badge--pw-click"
-                    :title="t('starrate', 'Passwort setzen / ändern')"
-                    @click="openPwEdit(share.token)"
+                    class="sr-share-list__badge sr-share-list__badge--pw"
+                    :title="t('starrate', 'Passwortgeschützt')"
                   >🔒</span>
                   <span
-                    v-if="share.permissions === 'rate'"
-                    class="sr-share-list__badge sr-share-list__badge--pick-click"
-                    :class="share.allow_pick ? 'sr-share-list__badge--pick-on' : 'sr-share-list__badge--pick-off'"
-                    :title="share.allow_pick ? t('starrate', 'Pick/Reject deaktivieren') : t('starrate', 'Pick/Reject aktivieren')"
-                    @click="togglePick(share)"
-                  >{{ share.allow_pick ? '✓' : '✗' }} Pick</span>
+                    v-if="share.permissions === 'rate' && share.allow_pick"
+                    class="sr-share-list__badge sr-share-list__badge--pick-on"
+                    :title="t('starrate', 'Pick/Reject erlaubt')"
+                  >✓ Pick</span>
                   <span
-                    class="sr-share-list__badge sr-share-list__badge--pick-click"
-                    :class="share.allow_export ? 'sr-share-list__badge--pick-on' : 'sr-share-list__badge--pick-off'"
-                    :title="share.allow_export ? t('starrate', 'Export deaktivieren') : t('starrate', 'Export aktivieren')"
-                    @click="toggleExport(share)"
-                  >{{ share.allow_export ? '✓' : '✗' }} Export</span>
+                    v-if="share.allow_export"
+                    class="sr-share-list__badge sr-share-list__badge--pick-on"
+                    :title="t('starrate', 'Export erlaubt')"
+                  >✓ Export</span>
                   <span
-                    class="sr-share-list__badge sr-share-list__badge--pick-click"
-                    :class="share.allow_comment ? 'sr-share-list__badge--pick-on' : 'sr-share-list__badge--pick-off'"
-                    :title="share.allow_comment ? t('starrate', 'Kommentare deaktivieren') : t('starrate', 'Kommentare aktivieren')"
-                    @click="toggleComment(share)"
-                  >{{ share.allow_comment ? '✓' : '✗' }} 💬</span>
+                    v-if="share.allow_comment"
+                    class="sr-share-list__badge sr-share-list__badge--pick-on"
+                    :title="t('starrate', 'Kommentare erlaubt')"
+                  >✓ 💬</span>
+                  <span
+                    v-if="share.recursive"
+                    class="sr-share-list__badge sr-share-list__badge--pick-on"
+                    :title="t('starrate', 'Rekursiv (alle Unterordner)') + (share.depth > 0 ? ` · ${t('starrate', 'Tiefe')} ${share.depth}` : '')"
+                  >↳<span v-if="share.depth > 0"> {{ share.depth }}</span></span>
                   <span v-if="share.expires_at" class="sr-share-list__badge" :class="isExpired(share) ? 'sr-share-list__badge--expired' : 'sr-share-list__badge--date'">
                     {{ isExpired(share) ? t('starrate', 'Abgelaufen') : formatDate(share.expires_at) }}
                   </span>
@@ -108,14 +110,13 @@
                   <button class="sr-share-list__confirm-no" @click="pendingClearToken = null">{{ t('starrate', 'Nein') }}</button>
                 </template>
                 <template v-else>
-                  <!-- Passwort-Button -->
+                  <!-- Bearbeiten — öffnet ShareModal im Edit-Mode -->
                   <button
                     class="sr-share-list__action-btn"
-                    :class="{ 'sr-share-list__action-btn--active': pwEditToken === share.token }"
-                    :title="t('starrate', 'Passwort setzen / ändern')"
-                    @click="openPwEdit(share.token)"
+                    :title="t('starrate', 'Bearbeiten')"
+                    @click="$emit('edit', share)"
                   >
-                    <svg viewBox="0 0 24 24" fill="none" width="14" height="14"><rect x="5" y="11" width="14" height="10" rx="2" stroke="currentColor" stroke-width="2"/><path d="M8 11V7a4 4 0 018 0" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                    <svg viewBox="0 0 24 24" fill="none" width="14" height="14"><path d="M12 20h9" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M16.5 3.5a2.121 2.121 0 113 3L7 19l-4 1 1-4L16.5 3.5z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/></svg>
                   </button>
                   <!-- Log-Button -->
                   <button
@@ -135,39 +136,6 @@
                     <svg viewBox="0 0 24 24" fill="none" width="14" height="14"><polyline points="3 6 5 6 21 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M19 6l-1 14H6L5 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M10 11v6M14 11v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
                   </button>
                 </template>
-              </div>
-            </div>
-
-            <!-- Passwort-Panel (aufklappbar) -->
-            <div v-if="pwEditToken === share.token" class="sr-share-list__pw-panel">
-              <div class="sr-share-list__pw-wrap">
-                <input
-                  v-model="pwInput"
-                  :type="showPwInput ? 'text' : 'password'"
-                  class="sr-share-list__pw-input"
-                  :placeholder="t('starrate', 'Neues Passwort…')"
-                  autocomplete="new-password"
-                  @keydown.enter="savePassword(share)"
-                  @keydown.escape="closePwEdit"
-                />
-                <button type="button" class="sr-share-list__pw-eye" @click="showPwInput = !showPwInput" :title="showPwInput ? t('starrate', 'Passwort verbergen') : t('starrate', 'Passwort anzeigen')">
-                  <svg v-if="!showPwInput" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                  <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
-                </button>
-              </div>
-              <div class="sr-share-list__pw-actions">
-                <button
-                  class="sr-share-list__pw-save"
-                  :disabled="!pwInput || pwSaving"
-                  @click="savePassword(share)"
-                >{{ t('starrate', 'Setzen') }}</button>
-                <button
-                  v-if="share.has_password"
-                  class="sr-share-list__pw-remove"
-                  :disabled="pwSaving"
-                  @click="removePassword(share)"
-                >{{ t('starrate', 'Entfernen') }}</button>
-                <button class="sr-share-list__pw-cancel" @click="closePwEdit">{{ t('starrate', 'Abbrechen') }}</button>
               </div>
             </div>
 
@@ -258,7 +226,7 @@ defineProps({
   ncPath: { type: String, default: '/' },
 })
 
-defineEmits(['close', 'create'])
+defineEmits(['close', 'create', 'edit'])
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -271,11 +239,6 @@ const copiedToken = ref(null)
 
 const pendingDeleteToken = ref(null)
 const pendingClearToken  = ref(null)
-
-const pwEditToken = ref(null)
-const pwInput     = ref('')
-const pwSaving    = ref(false)
-const showPwInput = ref(false)
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -318,39 +281,6 @@ async function loadShares() {
   }
 }
 
-async function togglePick(share) {
-  try {
-    const { data } = await axios.put(
-      generateUrl(`/apps/starrate/api/share/${share.token}`),
-      { allow_pick: !share.allow_pick }
-    )
-    const idx = shares.value.findIndex(s => s.token === share.token)
-    if (idx !== -1) shares.value[idx] = data.share
-  } catch { /* ignore */ }
-}
-
-async function toggleExport(share) {
-  try {
-    const { data } = await axios.put(
-      generateUrl(`/apps/starrate/api/share/${share.token}`),
-      { allow_export: !share.allow_export }
-    )
-    const idx = shares.value.findIndex(s => s.token === share.token)
-    if (idx !== -1) shares.value[idx] = data.share
-  } catch { /* ignore */ }
-}
-
-async function toggleComment(share) {
-  try {
-    const { data } = await axios.put(
-      generateUrl(`/apps/starrate/api/share/${share.token}`),
-      { allow_comment: !share.allow_comment }
-    )
-    const idx = shares.value.findIndex(s => s.token === share.token)
-    if (idx !== -1) shares.value[idx] = data.share
-  } catch { /* ignore */ }
-}
-
 async function toggleActive(share) {
   try {
     const { data } = await axios.put(
@@ -389,49 +319,6 @@ async function loadLog(token) {
     logs.value = { ...logs.value, [token]: data.log ?? [] }
   } finally {
     logsLoading.value = { ...logsLoading.value, [token]: false }
-  }
-}
-
-function openPwEdit(token) {
-  pwEditToken.value = pwEditToken.value === token ? null : token
-  pwInput.value = ''
-}
-
-function closePwEdit() {
-  pwEditToken.value = null
-  pwInput.value = ''
-  showPwInput.value = false
-}
-
-async function savePassword(share) {
-  if (!pwInput.value || pwSaving.value) return
-  pwSaving.value = true
-  try {
-    const { data } = await axios.put(
-      generateUrl(`/apps/starrate/api/share/${share.token}`),
-      { password: pwInput.value }
-    )
-    const idx = shares.value.findIndex(s => s.token === share.token)
-    if (idx !== -1) shares.value[idx] = data.share
-    closePwEdit()
-  } catch { /* ignore */ } finally {
-    pwSaving.value = false
-  }
-}
-
-async function removePassword(share) {
-  if (pwSaving.value) return
-  pwSaving.value = true
-  try {
-    const { data } = await axios.put(
-      generateUrl(`/apps/starrate/api/share/${share.token}`),
-      { password: null }
-    )
-    const idx = shares.value.findIndex(s => s.token === share.token)
-    if (idx !== -1) shares.value[idx] = data.share
-    closePwEdit()
-  } catch { /* ignore */ } finally {
-    pwSaving.value = false
   }
 }
 
@@ -586,10 +473,7 @@ defineExpose({ loadShares })
 .sr-share-list__badge--rate   { background: #2a1a1a; color: #e94560; }
 .sr-share-list__badge--filter { background: #2a2a1a; color: #f5c518; }
 .sr-share-list__badge--pw     { background: #2a2a3e; }
-.sr-share-list__badge--pick-click { cursor: pointer; transition: background 0.15s, color 0.15s; }
-.sr-share-list__badge--pick-click:hover { opacity: 0.85; }
 .sr-share-list__badge--pick-on  { background: #1a2a1a; color: #4caf50; }
-.sr-share-list__badge--pick-off { background: #2a2a3e; color: #52525b; }
 .sr-share-list__badge--date   { background: #1a2a1a; color: #7ecf7e; }
 .sr-share-list__badge--expired{ background: #3a1a1a; color: #e94560; }
 
@@ -772,81 +656,4 @@ defineExpose({ loadShares })
   flex-shrink: 0;
 }
 
-/* Passwort-Badge klickbar */
-.sr-share-list__badge--pw-click {
-  cursor: pointer;
-}
-.sr-share-list__badge--pw-click:hover { background: #3a2a4a; }
-
-/* Passwort-Panel */
-.sr-share-list__pw-panel {
-  background: #0f0f1a;
-  border-top: 1px solid #2a2a3e;
-  padding: 0.65rem 1.5rem;
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-.sr-share-list__pw-wrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-  flex: 1;
-}
-.sr-share-list__pw-input {
-  flex: 1;
-  min-width: 160px;
-  background: #16213e;
-  border: 1px solid #3f3f5a;
-  border-radius: 4px;
-  color: #d4d4d8;
-  font-size: 0.8rem;
-  padding: 0.3rem 2rem 0.3rem 0.6rem;
-}
-.sr-share-list__pw-input:focus { outline: none; border-color: #e94560; }
-.sr-share-list__pw-eye {
-  position: absolute;
-  right: 0.4rem;
-  background: none;
-  border: none;
-  color: #71717a;
-  cursor: pointer;
-  padding: 0;
-  display: flex;
-  align-items: center;
-}
-.sr-share-list__pw-eye:hover { color: #d4d4d8; }
-.sr-share-list__pw-actions { display: flex; gap: 0.35rem; flex-wrap: wrap; }
-.sr-share-list__pw-save {
-  background: #e94560;
-  border: none;
-  border-radius: 4px;
-  color: #fff;
-  cursor: pointer;
-  font-size: 0.75rem;
-  padding: 0.25rem 0.65rem;
-}
-.sr-share-list__pw-save:disabled { opacity: 0.4; cursor: not-allowed; }
-.sr-share-list__pw-remove {
-  background: none;
-  border: 1px solid #3f3f5a;
-  border-radius: 4px;
-  color: #71717a;
-  cursor: pointer;
-  font-size: 0.75rem;
-  padding: 0.25rem 0.65rem;
-}
-.sr-share-list__pw-remove:hover:not(:disabled) { color: #e94560; border-color: #e94560; }
-.sr-share-list__pw-remove:disabled { opacity: 0.4; cursor: not-allowed; }
-.sr-share-list__pw-cancel {
-  background: none;
-  border: 1px solid #2a2a3e;
-  border-radius: 4px;
-  color: #52525b;
-  cursor: pointer;
-  font-size: 0.75rem;
-  padding: 0.25rem 0.65rem;
-}
-.sr-share-list__pw-cancel:hover { color: #71717a; }
 </style>

--- a/src/components/ShareList.vue
+++ b/src/components/ShareList.vue
@@ -34,8 +34,13 @@
             <!-- Share-Zeile -->
             <div class="sr-share-list__row">
               <div class="sr-share-list__info">
-                <span class="sr-share-list__path">{{ share.nc_path || '/' }}</span>
-                <span v-if="share.guest_name" class="sr-share-list__guest-name">{{ share.guest_name }}</span>
+                <div class="sr-share-list__title-row">
+                  <span class="sr-share-list__path">{{ share.nc_path || '/' }}</span>
+                  <template v-if="share.guest_name">
+                    <span class="sr-share-list__guest-sep">—</span>
+                    <span class="sr-share-list__guest-name">{{ share.guest_name }}</span>
+                  </template>
+                </div>
                 <div class="sr-share-list__meta">
                   <span class="sr-share-list__badge" :class="share.permissions === 'rate' ? 'sr-share-list__badge--rate' : 'sr-share-list__badge--view'">
                     {{ share.permissions === 'rate' ? t('starrate', 'Bewerten') : t('starrate', 'Ansehen') }}
@@ -444,16 +449,28 @@ defineExpose({ loadShares })
   gap: 0.35rem;
 }
 
+.sr-share-list__title-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
 .sr-share-list__path {
   color: #fff;
   font-size: 0.875rem;
   font-weight: 500;
   word-break: break-all;
 }
-.sr-share-list__guest-name {
-  color: #d4d4d8;
+.sr-share-list__guest-sep {
+  color: #52525b;
   font-size: 0.875rem;
-  font-weight: 500;
+}
+.sr-share-list__guest-name {
+  /* Heller Grauton, weniger Aufmerksamkeit als der Pfad — der Pfad ist die
+     primäre Identität des Shares, der Empfängername sekundär. */
+  color: #a1a1aa;
+  font-size: 0.875rem;
+  font-weight: 400;
 }
 
 .sr-share-list__meta {

--- a/src/components/ShareModal.vue
+++ b/src/components/ShareModal.vue
@@ -3,7 +3,9 @@
     <div class="sr-share-modal__overlay" @click.self="$emit('close')">
       <div class="sr-share-modal">
         <header class="sr-share-modal__header">
-          <h2 class="sr-share-modal__title">{{ t('starrate', 'Neuen Freigabe-Link erstellen') }}</h2>
+          <h2 class="sr-share-modal__title">
+            {{ isEditMode ? t('starrate', 'Freigabe bearbeiten') : t('starrate', 'Neuen Freigabe-Link erstellen') }}
+          </h2>
           <button class="sr-share-modal__close" @click="$emit('close')">✕</button>
         </header>
 
@@ -40,7 +42,22 @@
 
           <div class="sr-share-modal__field">
             <label class="sr-share-modal__label">{{ t('starrate', 'Ordner') }}</label>
-            <input class="sr-share-modal__input sr-share-modal__input--readonly" readonly :value="ncPath" />
+            <!-- Im Edit-Mode editierbar: User kann den Pfad eines Shares ändern.
+                 Im Create-Mode readonly: vorbefüllt mit dem aktuellen Gallery-Pfad. -->
+            <input
+              v-if="isEditMode"
+              v-model="form.ncPath"
+              class="sr-share-modal__input"
+              type="text"
+              :placeholder="t('starrate', '/Pfad/zum/Ordner')"
+              @blur="onPathBlur"
+            />
+            <input
+              v-else
+              class="sr-share-modal__input sr-share-modal__input--readonly"
+              readonly
+              :value="form.ncPath"
+            />
           </div>
 
           <div class="sr-share-modal__field">
@@ -101,6 +118,26 @@
             </span>
           </div>
 
+          <!-- Rekursive Ansicht: nur sichtbar wenn Master-Schalter in den
+               persönlichen Settings aktiv ist. -->
+          <div v-if="recursionEnabled" class="sr-share-modal__field">
+            <label class="sr-share-modal__checkbox-label">
+              <input type="checkbox" v-model="form.recursive" class="sr-share-modal__checkbox" data-testid="recursive" />
+              {{ t('starrate', 'Rekursive Ansicht (alle Bilder aus Unterordnern)') }}
+            </label>
+          </div>
+
+          <div v-if="recursionEnabled && form.recursive" class="sr-share-modal__field">
+            <label class="sr-share-modal__label">{{ t('starrate', 'Gruppen-Tiefe') }}</label>
+            <select class="sr-share-modal__select" v-model.number="form.depth">
+              <option :value="0">{{ t('starrate', 'Flach (keine Gruppierung)') }}</option>
+              <option :value="1">1</option>
+              <option :value="2">2</option>
+              <option :value="3">3</option>
+              <option :value="4">4</option>
+            </select>
+          </div>
+
           <div class="sr-share-modal__field">
             <label class="sr-share-modal__label">{{ t('starrate', 'Vorfilter (Mindest-Bewertung)') }}</label>
             <select class="sr-share-modal__select" v-model="form.minRating">
@@ -114,13 +151,21 @@
           </div>
 
           <div class="sr-share-modal__field">
-            <label class="sr-share-modal__label">{{ t('starrate', 'Passwort') }} <span class="sr-share-modal__optional">({{ t('starrate', 'optional') }})</span></label>
+            <label class="sr-share-modal__label">
+              {{ t('starrate', 'Passwort') }}
+              <span v-if="!isEditMode" class="sr-share-modal__optional">({{ t('starrate', 'optional') }})</span>
+              <span v-else-if="editShare?.has_password" class="sr-share-modal__optional">({{ t('starrate', 'gesetzt — leer lassen zum Beibehalten') }})</span>
+              <span v-else class="sr-share-modal__optional">({{ t('starrate', 'optional, leer lassen = kein Passwort') }})</span>
+            </label>
             <div class="sr-share-modal__pw-wrap">
               <input
                 v-model="form.password"
                 class="sr-share-modal__input sr-share-modal__input--pw"
                 :type="showPassword ? 'text' : 'password'"
-                :placeholder="t('starrate', 'Leer lassen = kein Passwort')"
+                :placeholder="isEditMode && editShare?.has_password
+                  ? t('starrate', '••••••••  (leer lassen zum Beibehalten)')
+                  : t('starrate', 'Leer lassen = kein Passwort')"
+                :disabled="form.removePassword"
                 autocomplete="new-password"
               />
               <button type="button" class="sr-share-modal__pw-eye" @click="showPassword = !showPassword" :title="showPassword ? t('starrate', 'Passwort verbergen') : t('starrate', 'Passwort anzeigen')">
@@ -128,6 +173,11 @@
                 <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
               </button>
             </div>
+            <!-- Nur sichtbar im Edit-Mode wenn aktuell ein Passwort gesetzt ist -->
+            <label v-if="isEditMode && editShare?.has_password" class="sr-share-modal__checkbox-label sr-share-modal__pw-remove">
+              <input type="checkbox" v-model="form.removePassword" class="sr-share-modal__checkbox" />
+              {{ t('starrate', 'Passwort entfernen (Share öffentlich machen)') }}
+            </label>
           </div>
 
           <div class="sr-share-modal__field">
@@ -147,7 +197,7 @@
               {{ t('starrate', 'Abbrechen') }}
             </button>
             <button type="submit" class="sr-share-modal__btn sr-share-modal__btn--primary" :disabled="saving">
-              {{ saving ? t('starrate', 'Erstelle…') : t('starrate', 'Link erstellen') }}
+              {{ submitLabel }}
             </button>
           </div>
         </form>
@@ -162,34 +212,108 @@ import { ref, computed } from 'vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { t } from '@nextcloud/l10n'
+import { readFolderState } from '../utils/folderRecursiveState.js'
 
 const props = defineProps({
   ncPath:                  { type: String,  default: '/' },
   commentsGloballyEnabled: { type: Boolean, default: false },
+  // Recursive-View Settings — bestimmen ob die zwei neuen Felder gerendert werden,
+  // und liefern Defaults für neue Shares (zusammen mit folderRecursiveState).
+  recursionEnabled:        { type: Boolean, default: false },
+  recursiveDefault:        { type: Boolean, default: false },
+  recursiveDefaultDepth:   { type: Number,  default: 0 },
+  // Edit-Modus: wenn gesetzt, prefilled wir das Formular mit den Werten aus
+  // diesem Share und schicken PUT statt POST.
+  editShare:               { type: Object,  default: null },
 })
 
-const emit = defineEmits(['close', 'created'])
+const emit = defineEmits(['close', 'created', 'updated'])
+
+const isEditMode = computed(() => !!props.editShare)
+
+const submitLabel = computed(() => {
+  if (saving.value) return isEditMode.value ? t('starrate', 'Speichere…') : t('starrate', 'Erstelle…')
+  return isEditMode.value ? t('starrate', 'Speichern') : t('starrate', 'Link erstellen')
+})
 
 // ── Formular-State ────────────────────────────────────────────────────────────
+//
+// resolveRecursive: Hierarchie für die Recursive-Felder beim Anlegen oder bei
+// Pfad-Wechsel im Edit-Mode. Spiegelt die Logik aus Gallery.vue:
+//   localStorage[path] ?? settings-default
+//
+// Im Edit-Mode initial: NICHT diese Funktion verwenden, sondern die im Share
+// gespeicherten Werte. Nur bei expliziter Pfad-Änderung (onPathBlur) greift
+// sie wie bei einer Anlage.
 
-const form = ref({
-  guestName:    '',
-  permissions:  'rate',
-  allowPick:    false,
-  allowExport:  false,
-  allowComment: false,
-  minRating:    0,
-  password:     '',
-  expiresDate:  '',
-})
+function resolveRecursive(path) {
+  const stored = readFolderState(path)
+  if (stored) return { recursive: stored.recursive, depth: stored.depth }
+  return {
+    recursive: props.recursiveDefault,
+    depth: props.recursiveDefaultDepth,
+  }
+}
 
-const saving      = ref(false)
-const formError   = ref('')
+function buildInitialForm() {
+  const e = props.editShare
+  if (e) {
+    return {
+      ncPath:        e.nc_path || '/',
+      guestName:     e.guest_name || '',
+      permissions:   e.permissions || 'rate',
+      allowPick:     !!e.allow_pick,
+      allowExport:   !!e.allow_export,
+      allowComment:  !!e.allow_comment,
+      minRating:     e.min_rating ?? 0,
+      recursive:     !!e.recursive,
+      depth:         e.depth ?? 0,
+      password:      '',           // im Edit-Mode immer leer, Logik unten
+      removePassword: false,
+      expiresDate:   e.expires_at
+        ? new Date(e.expires_at * 1000).toISOString().split('T')[0]
+        : '',
+    }
+  }
+  // Anlage: Defaults (Pfad vom aktuellen Folder), recursive aus
+  // folderRecursiveState→Settings-Hierarchie
+  const rec = resolveRecursive(props.ncPath)
+  return {
+    ncPath:        props.ncPath,
+    guestName:     '',
+    permissions:   'rate',
+    allowPick:     false,
+    allowExport:   false,
+    allowComment:  false,
+    minRating:     0,
+    recursive:     rec.recursive,
+    depth:         rec.depth,
+    password:      '',
+    removePassword: false,
+    expiresDate:   '',
+  }
+}
+
+const form = ref(buildInitialForm())
+
+const saving       = ref(false)
+const formError    = ref('')
 const createdShare = ref(null)
-const copied      = ref(false)
+const copied       = ref(false)
 const showPassword = ref(false)
 
 const todayStr = computed(() => new Date().toISOString().split('T')[0])
+
+// Pfad-Blur: nur Edit-Mode + falls Recursion aktiviert. Pfad-Wechsel löst
+// die "wie bei Anlage"-Logik aus — User-Wunsch: "wenn ich Sarahs Share auf
+// einen anderen Folder umschreibe, soll der Default für den neuen Folder
+// greifen". Werte werden überschrieben, User kann danach manuell anpassen.
+function onPathBlur() {
+  if (!isEditMode.value || !props.recursionEnabled) return
+  const rec = resolveRecursive(form.value.ncPath)
+  form.value.recursive = rec.recursive
+  form.value.depth     = rec.depth
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -214,10 +338,10 @@ async function copyUrl() {
 function reset() {
   createdShare.value = null
   formError.value    = ''
-  form.value = { guestName: '', permissions: 'rate', allowPick: false, allowExport: false, allowComment: false, minRating: 0, password: '', expiresDate: '' }
+  form.value         = buildInitialForm()
 }
 
-// ── Create ────────────────────────────────────────────────────────────────────
+// ── Submit (Create oder Update) ──────────────────────────────────────────────
 
 async function create() {
   formError.value = ''
@@ -231,19 +355,34 @@ async function create() {
   }
 
   const body = {
-    nc_path:      props.ncPath,
+    nc_path:      form.value.ncPath,
     permissions:  form.value.permissions,
     allow_pick:    form.value.permissions === 'rate' && form.value.allowPick,
     allow_export:  form.value.allowExport,
     allow_comment: form.value.allowComment && props.commentsGloballyEnabled,
     min_rating:   form.value.minRating,
+    recursive:    !!form.value.recursive,
+    depth:        Number(form.value.depth) || 0,
   }
 
   if (form.value.guestName.trim()) {
     body.guest_name = form.value.guestName.trim()
   }
 
-  if (form.value.password) {
+  // Passwort-Logik:
+  // - Create: gefülltes Feld → Passwort setzen, leer → kein Passwort
+  // - Edit: removePassword=true → password=null senden (entfernt es), sonst
+  //   gefülltes Feld → ändern, leeres Feld + removePassword=false → key NICHT
+  //   senden (Backend lässt bestehenden Hash unangetastet via array_key_exists-
+  //   Check in updateShare).
+  if (isEditMode.value) {
+    if (form.value.removePassword) {
+      body.password = null
+    } else if (form.value.password) {
+      body.password = form.value.password
+    }
+    // sonst: kein password-Key im Body
+  } else if (form.value.password) {
     body.password = form.value.password
   }
 
@@ -251,15 +390,28 @@ async function create() {
     // Datum in Unix-Timestamp (End des Tages, lokale Zeit)
     const d = new Date(form.value.expiresDate + 'T23:59:59')
     body.expires_at = Math.floor(d.getTime() / 1000)
+  } else if (isEditMode.value && props.editShare?.expires_at) {
+    // Edit-Mode: User hat das Datum gelöscht → Backend ignoriert das aktuell
+    // (kein expires_at-Key reicht zum Beibehalten). Falls echte Entfernung
+    // gewünscht: extra Flag wie bei Passwort. Für V1.3.1 lassen wir das aus
+    // Scope — bisher kann man Datum nicht zurücksetzen.
   }
 
   try {
-    const url = generateUrl('/apps/starrate/api/share')
-    const { data } = await axios.post(url, body)
-    createdShare.value = data.share
-    emit('created', data.share)
+    if (isEditMode.value) {
+      const url = generateUrl(`/apps/starrate/api/share/${props.editShare.token}`)
+      const { data } = await axios.put(url, body)
+      emit('updated', data.share ?? data)
+      emit('close')
+    } else {
+      const url = generateUrl('/apps/starrate/api/share')
+      const { data } = await axios.post(url, body)
+      createdShare.value = data.share
+      emit('created', data.share)
+    }
   } catch (e) {
-    formError.value = e?.response?.data?.error ?? t('starrate', 'Fehler beim Erstellen des Links')
+    formError.value = e?.response?.data?.error
+      ?? t('starrate', isEditMode.value ? 'Fehler beim Speichern' : 'Fehler beim Erstellen des Links')
   } finally {
     saving.value = false
   }

--- a/src/utils/folderRecursiveState.js
+++ b/src/utils/folderRecursiveState.js
@@ -1,0 +1,116 @@
+/**
+ * Per-Folder-Memory für die rekursive Ansicht.
+ *
+ * Speichert pro Folder-Pfad das zuletzt gewählte recursive/depth-Setting in
+ * localStorage. Damit kommt der User beim Wiederbetreten desselben Folders in
+ * den gleichen View zurück, ohne dass er global oder per Settings nachjustieren
+ * muss. URL-Query-Params toppen weiterhin (Sharing-Use-Case).
+ *
+ * Hierarchie der Quellen (höchste Priorität zuerst):
+ *   1. URL-Query (?recursive=…&depth=…)
+ *   2. localStorage (dieses Modul)
+ *   3. Personal Settings Default
+ *
+ * Cap: 50 Einträge. Beim Überlauf werden die ältesten herausgeworfen
+ * (insertion-order). Dadurch bleibt localStorage klein, ohne Komfort-Verlust
+ * für den realistischen Workflow.
+ */
+
+const STORAGE_KEY = 'starrate_folder_recursive_v1'
+const MAX_ENTRIES = 50
+
+/**
+ * Lade die gesamte Map. Defensiv gegen kaputte/fehlende Daten.
+ * @returns {Object<string, {recursive: boolean, depth: number}>}
+ */
+function loadMap() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    // Quota, Privacy-Mode, kaputtes JSON — alles gleich behandelt
+    return {}
+  }
+}
+
+/**
+ * Speichere die Map. Trimmt auf MAX_ENTRIES (älteste raus).
+ */
+function saveMap(map) {
+  try {
+    const keys = Object.keys(map)
+    if (keys.length > MAX_ENTRIES) {
+      // Älteste Insertion-Order-Einträge droppen
+      const trimmed = {}
+      const keepKeys = keys.slice(keys.length - MAX_ENTRIES)
+      for (const k of keepKeys) trimmed[k] = map[k]
+      map = trimmed
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Quota/Privacy-Mode — silent fail, Memory-Verhalten degradiert auf
+    // settings-default, aber app läuft weiter.
+  }
+}
+
+/**
+ * Lese den gespeicherten State für einen Folder-Pfad.
+ * @param {string} path — z.B. '/Photos/2026'
+ * @returns {{recursive: boolean, depth: number} | null}
+ */
+export function readFolderState(path) {
+  if (!path) return null
+  const map = loadMap()
+  const entry = map[path]
+  if (!entry) return null
+  // Validation gegen kaputte/manipulierte Werte
+  const recursive = entry.recursive === true
+  const depth = Number.isInteger(entry.depth) && entry.depth >= 0 && entry.depth <= 4
+    ? entry.depth
+    : 0
+  return { recursive, depth }
+}
+
+/**
+ * Speichere den State für einen Folder-Pfad. Re-Write desselben Keys schiebt
+ * ihn ans Ende der Insertion-Order (jüngster Eintrag zuletzt) — wichtig für
+ * die Eviction-Logik beim Cap-Überlauf.
+ * @param {string} path
+ * @param {boolean} recursive
+ * @param {number} depth — 0..4
+ */
+export function writeFolderState(path, recursive, depth) {
+  if (!path) return
+  const map = loadMap()
+  // Re-Insert um Insertion-Order zu erneuern
+  delete map[path]
+  map[path] = {
+    recursive: !!recursive,
+    depth: Number.isInteger(depth) ? Math.max(0, Math.min(4, depth)) : 0,
+  }
+  saveMap(map)
+}
+
+/**
+ * Entferne den State für einen Folder-Pfad (z.B. wenn der User die Default-
+ * Konfig wiederherstellen will). Aktuell nicht aus der UI aufrufbar, aber
+ * für künftige „Reset"-Aktionen vorbereitet.
+ */
+export function clearFolderState(path) {
+  if (!path) return
+  const map = loadMap()
+  if (path in map) {
+    delete map[path]
+    saveMap(map)
+  }
+}
+
+/**
+ * Lösche alle gespeicherten Folder-States. Für Logout-Cleanup oder
+ * Diagnose-Zwecke.
+ */
+export function clearAllFolderStates() {
+  try { localStorage.removeItem(STORAGE_KEY) } catch { /* ignore */ }
+}

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -165,16 +165,22 @@
       ref="shareListRef"
       :nc-path="currentPath"
       @close="showShareList = false"
-      @create="showShareModal = true"
+      @create="openShareModalForCreate"
+      @edit="openShareModalForEdit"
     />
 
-    <!-- Share erstellen -->
+    <!-- Share anlegen oder bearbeiten — gleicher Modal, Modus per editingShare -->
     <ShareModal
       v-if="!guestMode && showShareModal"
       :nc-path="currentPath"
       :comments-globally-enabled="settings.comments_enabled"
-      @close="showShareModal = false"
+      :recursion-enabled="!!settings.recursion_enabled"
+      :recursive-default="!!settings.recursive_default"
+      :recursive-default-depth="settings.recursive_default_depth"
+      :edit-share="editingShare"
+      @close="closeShareModal"
       @created="onShareCreated"
+      @updated="onShareUpdated"
     />
 
     <!-- Export List Modal -->
@@ -823,9 +829,30 @@ function showToast(message, type = 'success', duration = 3000) {
 
 // ─── Share ────────────────────────────────────────────────────────────────────
 
-function onShareCreated() {
+const editingShare = ref(null)
+
+function openShareModalForCreate() {
+  editingShare.value = null
+  showShareModal.value = true
+}
+
+function openShareModalForEdit(share) {
+  editingShare.value = share
+  showShareModal.value = true
+}
+
+function closeShareModal() {
   showShareModal.value = false
-  // Liste neu laden damit der neue Share erscheint
+  editingShare.value   = null
+}
+
+function onShareCreated() {
+  closeShareModal()
+  shareListRef.value?.loadShares()
+}
+
+function onShareUpdated() {
+  closeShareModal()
   shareListRef.value?.loadShares()
 }
 

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -267,6 +267,7 @@ import ShareModal from '../components/ShareModal.vue'
 import ShareList from '../components/ShareList.vue'
 import ExportModal from '../components/ExportModal.vue'
 import FolderPopover from '../components/FolderPopover.vue'
+import { readFolderState, writeFolderState } from '../utils/folderRecursiveState.js'
 
 // ─── Gast-Modus-Props (alle optional, Defaults = normales Verhalten) ───────────
 
@@ -349,17 +350,19 @@ const currentPath = computed(() => {
   return p ? `/${Array.isArray(p) ? p.join('/') : p}` : '/'
 })
 
-// ─── Recursive-View State (URL überschreibt Settings-Default) ─────────────────
+// ─── Recursive-View State (URL > localStorage > Settings-Default) ─────────────
 //
 // Master-Schalter recursion_enabled (User-Setting, Default false): wenn aus,
 // wird das gesamte Feature inkl. URL-Param-Auswertung neutralisiert. Damit
 // können Nutzer das Feature vollständig ausblenden, und ein versehentlicher
 // Share-Link mit ?recursive=1 hat keinen Effekt.
 //
-// recursive: ?recursive=1 (oder true) in der URL aktiviert; sonst Settings-
-// Default. depth: ?depth=N (0-4) in der URL gewinnt; sonst Settings-Default.
-// Pro Folder, weil Vue-Router den ganzen URL-State per Folder hält. Browser-
-// Back navigiert zurück inkl. der Recursive-Settings.
+// Hierarchie der Werte-Quellen (höchste Priorität zuerst):
+//   1. URL-Query (?recursive=… / ?depth=…) — Sharing/Bookmarking
+//   2. Per-Folder-Memory (localStorage via folderRecursiveState) — Convenience
+//      damit der User beim Wiederbesuch desselben Folders an seinem Toggle-
+//      Zustand andockt, ohne URL-Manipulation
+//   3. Personal Settings Default — globaler Fallback
 //
 // Im Gast-Modus immer aus — Guest-API unterstützt Recursive aktuell nicht.
 const recursionAvailable = computed(() => !props.guestMode && !!settings.value.recursion_enabled)
@@ -368,6 +371,8 @@ const recursive = computed(() => {
   if (!recursionAvailable.value) return false
   const q = route.query.recursive
   if (q !== undefined) return q === '1' || q === 'true'
+  const stored = readFolderState(currentPath.value)
+  if (stored) return stored.recursive
   return settings.value.recursive_default
 })
 
@@ -378,6 +383,8 @@ const depth = computed(() => {
     const d = parseInt(q, 10)
     if (Number.isFinite(d) && d >= 0 && d <= 4) return d
   }
+  const stored = readFolderState(currentPath.value)
+  if (stored) return stored.depth
   return settings.value.recursive_default_depth
 })
 
@@ -417,13 +424,20 @@ function exitRecursionInto(segmentIndex) {
 // FilterBar-Toggle/Stepper schreiben in URL-Query — die Computed-Werte oben
 // reagieren darauf und triggern via Watch das Reload. Wir mergen in die
 // existierende Query, damit andere URL-Params (Filter etc.) erhalten bleiben.
+//
+// Zusätzlich persistieren wir den neuen Zustand pro Folder in localStorage,
+// damit der User beim Wiederbesuch desselben Folders dort weiterarbeitet wo
+// er aufgehört hat — ohne URL-Manipulation. Bewusst NICHT bei reinen URL-
+// Aufrufen (z.B. von einem Share-Link), nur bei expliziter UI-Interaktion.
 function setRecursive(value) {
   const q = { ...route.query, recursive: value ? '1' : '0' }
   router.replace({ path: route.path, query: q })
+  writeFolderState(currentPath.value, value, depth.value)
 }
 function setDepth(value) {
   const q = { ...route.query, depth: String(value) }
   router.replace({ path: route.path, query: q })
+  writeFolderState(currentPath.value, recursive.value, value)
 }
 
 const pathSegments = computed(() =>

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -131,6 +131,61 @@ class ShareServiceTest extends TestCase
         $this->assertSame(5, $share['min_rating']); // auf 5 begrenzt
     }
 
+    // ─── Tests: Recursive + Depth ─────────────────────────────────────────────
+
+    public function testCreateShareWithRecursiveAndDepth(): void
+    {
+        $this->secureRandom->method('generate')->willReturn(self::SAMPLE_TOKEN);
+        $saved = null;
+        $this->config->method('getUserValue')->willReturn('{}');
+        $this->config->method('setUserValue')
+            ->willReturnCallback(function ($uid, $app, $key, $val) use (&$saved) {
+                $saved = $val;
+            });
+
+        $share = $this->service->createShare(
+            self::OWNER_ID, '/Fotos', null, null, 0, ShareService::PERM_VIEW,
+            null, false, false, false,
+            true, 2,  // recursive, depth
+        );
+
+        $this->assertTrue($share['recursive']);
+        $this->assertSame(2, $share['depth']);
+        // Im persistierten JSON müssen die Werte ebenfalls drin sein
+        $persisted = json_decode($saved, true)[self::SAMPLE_TOKEN];
+        $this->assertTrue($persisted['recursive']);
+        $this->assertSame(2, $persisted['depth']);
+    }
+
+    public function testCreateShareDepthClampedTo0to4(): void
+    {
+        $this->secureRandom->method('generate')->willReturn(self::SAMPLE_TOKEN);
+        $this->config->method('getUserValue')->willReturn('{}');
+        $this->config->method('setUserValue');
+
+        $share = $this->service->createShare(
+            self::OWNER_ID, '/Fotos', null, null, 0, ShareService::PERM_VIEW,
+            null, false, false, false, true, 99,
+        );
+
+        $this->assertSame(4, $share['depth']);
+    }
+
+    public function testCreateShareDefaultsRecursiveFalse(): void
+    {
+        $this->secureRandom->method('generate')->willReturn(self::SAMPLE_TOKEN);
+        $this->config->method('getUserValue')->willReturn('{}');
+        $this->config->method('setUserValue');
+
+        // Old-style call ohne recursive/depth-Args → recursive=false, depth=0
+        $share = $this->service->createShare(
+            self::OWNER_ID, '/Fotos', null, null, 0, ShareService::PERM_VIEW
+        );
+
+        $this->assertFalse($share['recursive']);
+        $this->assertSame(0, $share['depth']);
+    }
+
     // ─── Tests: Share validieren ──────────────────────────────────────────────
 
     public function testIsShareValidReturnsTrueForActiveShare(): void

--- a/tests/js/Gallery.spec.js
+++ b/tests/js/Gallery.spec.js
@@ -630,4 +630,74 @@ describe('Gallery – Recursive View', () => {
     await flushPromises()
     expect(w.findAll('.sr-breadcrumb__seg--dynamic')).toHaveLength(0)
   })
+
+  // ── Per-Folder-Memory (localStorage) ──────────────────────────────────────
+
+  it('FilterBar-Toggle persistiert Recursive-State pro Folder im localStorage', async () => {
+    localStorage.clear()
+    const { w } = await factoryNonGuest({
+      settings: { recursion_enabled: true },
+      path: '/folder/Photos',
+    })
+    await flushPromises()
+
+    await w.findComponent({ name: 'FilterBar' }).vm.$emit('update:recursive', true)
+    await flushPromises()
+
+    // localStorage hat den Eintrag — anders als der reine URL-Pfad
+    const raw = localStorage.getItem('starrate_folder_recursive_v1')
+    expect(raw).toBeTruthy()
+    const map = JSON.parse(raw)
+    expect(map['/Photos']).toEqual({ recursive: true, depth: 0 })
+  })
+
+  it('Tiefe-Update persistiert Recursive+Depth zusammen', async () => {
+    localStorage.clear()
+    const { w } = await factoryNonGuest({
+      settings: { recursion_enabled: true, recursive_default: true },
+      path: '/folder/Photos',
+    })
+    await flushPromises()
+
+    await w.findComponent({ name: 'FilterBar' }).vm.$emit('update:depth', 3)
+    await flushPromises()
+
+    const map = JSON.parse(localStorage.getItem('starrate_folder_recursive_v1'))
+    expect(map['/Photos']).toEqual({ recursive: true, depth: 3 })
+  })
+
+  it('localStorage-State wird beim Folder-Open gelesen (vor Settings-Default)', async () => {
+    localStorage.clear()
+    localStorage.setItem('starrate_folder_recursive_v1', JSON.stringify({
+      '/Photos': { recursive: true, depth: 2 },
+    }))
+
+    // Settings-Default ist false/0, aber localStorage gewinnt
+    const { w } = await factoryNonGuest({
+      settings: { recursion_enabled: true, recursive_default: false, recursive_default_depth: 0 },
+      path: '/folder/Photos',
+    })
+    await flushPromises()
+
+    const fb = w.findComponent({ name: 'FilterBar' })
+    expect(fb.props('recursive')).toBe(true)
+    expect(fb.props('depth')).toBe(2)
+  })
+
+  it('URL-Query gewinnt vor localStorage', async () => {
+    localStorage.setItem('starrate_folder_recursive_v1', JSON.stringify({
+      '/Photos': { recursive: true, depth: 4 },
+    }))
+
+    const { w } = await factoryNonGuest({
+      settings: { recursion_enabled: true },
+      path: '/folder/Photos',
+      query: { recursive: '0', depth: '1' },  // URL überschreibt
+    })
+    await flushPromises()
+
+    const fb = w.findComponent({ name: 'FilterBar' })
+    expect(fb.props('recursive')).toBe(false)
+    expect(fb.props('depth')).toBe(1)
+  })
 })

--- a/tests/js/ShareModal.spec.js
+++ b/tests/js/ShareModal.spec.js
@@ -286,4 +286,190 @@ describe('ShareModal', () => {
     await w.find('.sr-share-modal__overlay').trigger('click')
     expect(w.emitted('close')).toBeTruthy()
   })
+
+  // ── Recursive-Felder (V1.3.1) ─────────────────────────────────────────────
+
+  it('Recursive-Felder hidden wenn recursionEnabled=false (Default)', () => {
+    const w = factory()
+    expect(w.find('[data-testid="recursive"]').exists()).toBe(false)
+  })
+
+  it('Recursive-Checkbox sichtbar wenn recursionEnabled=true', () => {
+    const w = factory({ recursionEnabled: true })
+    expect(w.find('[data-testid="recursive"]').exists()).toBe(true)
+  })
+
+  it('Tiefe-Dropdown nur sichtbar wenn recursive UND recursionEnabled', async () => {
+    const w = factory({ recursionEnabled: true, recursiveDefault: false })
+    // Bei initial recursive=false → Tiefe versteckt
+    expect(w.find('.sr-share-modal__select').exists()).toBe(true)  // minRating-Select existiert
+    // Tiefe-Select ist nicht der einzige select; check ob "Gruppen-Tiefe"-Label da
+    expect(w.text()).not.toContain('Gruppen-Tiefe')
+
+    // Recursive an → Tiefe-Label sichtbar
+    await w.find('[data-testid="recursive"]').setValue(true)
+    expect(w.text()).toContain('Gruppen-Tiefe')
+  })
+
+  it('Recursive-Default (settings) wird beim Anlegen vorbefüllt', () => {
+    const w = factory({
+      recursionEnabled: true,
+      recursiveDefault: true,
+      recursiveDefaultDepth: 2,
+    })
+    expect(w.find('[data-testid="recursive"]').element.checked).toBe(true)
+  })
+
+  // ── Edit-Mode (V1.3.1) ────────────────────────────────────────────────────
+
+  const sampleShare = {
+    token: 'abc123',
+    nc_path: '/Fotos/Wedding',
+    permissions: 'rate',
+    allow_pick: true,
+    allow_export: false,
+    allow_comment: false,
+    min_rating: 3,
+    recursive: true,
+    depth: 2,
+    has_password: true,
+    expires_at: null,
+    guest_name: 'Sarah',
+    active: true,
+  }
+
+  it('Edit-Mode: Titel ändert sich auf "Freigabe bearbeiten"', () => {
+    const w = factory({ editShare: sampleShare })
+    expect(w.find('.sr-share-modal__title').text()).toContain('bearbeiten')
+  })
+
+  it('Edit-Mode: Submit-Button hat Label "Speichern"', () => {
+    const w = factory({ editShare: sampleShare })
+    expect(w.find('.sr-share-modal__btn--primary').text()).toContain('Speichern')
+  })
+
+  it('Edit-Mode: Pfad-Input ist editierbar (nicht readonly)', () => {
+    const w = factory({ editShare: sampleShare })
+    // Im Edit-Mode kein readonly-Input mehr, sondern editierbarer
+    expect(w.find('.sr-share-modal__input--readonly').exists()).toBe(false)
+    const inputs = w.findAll('input.sr-share-modal__input[type="text"]')
+    // Erstes Text-Input ist der Pfad
+    expect(inputs[0].element.value).toBe('/Fotos/Wedding')
+  })
+
+  it('Edit-Mode: Felder werden aus Share vorbefüllt', () => {
+    const w = factory({
+      editShare: sampleShare,
+      recursionEnabled: true,
+    })
+    // Permissions
+    const toggles = w.findAll('.sr-share-modal__toggle')
+    expect(toggles[1].classes()).toContain('sr-share-modal__toggle--active') // 'rate'
+    // Pick-Checkbox
+    expect(w.find('[data-testid="allow-pick"]').element.checked).toBe(true)
+    // Recursive
+    expect(w.find('[data-testid="recursive"]').element.checked).toBe(true)
+    // GuestName
+    expect(w.findAll('input[type="text"]')[1].element.value).toBe('Sarah')
+  })
+
+  it('Edit-Mode: Passwort-Feld leer, Remove-Checkbox bei has_password=true sichtbar', () => {
+    const w = factory({ editShare: sampleShare })
+    expect(w.find('.sr-share-modal__input--pw').element.value).toBe('')
+    expect(w.text()).toContain('Passwort entfernen')
+  })
+
+  it('Edit-Mode: Remove-Checkbox bei has_password=false NICHT sichtbar', () => {
+    const w = factory({ editShare: { ...sampleShare, has_password: false } })
+    expect(w.text()).not.toContain('Passwort entfernen')
+  })
+
+  it('Edit-Submit ruft PUT, nicht POST', async () => {
+    axios.put.mockResolvedValueOnce({ data: { share: { ...sampleShare } } })
+    const w = factory({ editShare: sampleShare })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(axios.put).toHaveBeenCalled()
+    expect(axios.post).not.toHaveBeenCalled()
+    // URL enthält den Token
+    expect(axios.put.mock.calls[0][0]).toContain(sampleShare.token)
+  })
+
+  it('Edit-Submit: leeres Passwort + removePassword=false → kein password-Key im Body', async () => {
+    axios.put.mockResolvedValueOnce({ data: { share: sampleShare } })
+    const w = factory({ editShare: sampleShare })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    const body = axios.put.mock.calls[0][1]
+    expect(body).not.toHaveProperty('password')
+  })
+
+  it('Edit-Submit: removePassword=true → password=null im Body', async () => {
+    axios.put.mockResolvedValueOnce({ data: { share: sampleShare } })
+    const w = factory({ editShare: sampleShare })
+    // Remove-Checkbox aktivieren
+    const checkboxes = w.findAll('.sr-share-modal__checkbox')
+    const removeCheckbox = checkboxes[checkboxes.length - 1] // letzte Checkbox = Remove
+    await removeCheckbox.setValue(true)
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    const body = axios.put.mock.calls[0][1]
+    expect(body.password).toBeNull()
+  })
+
+  it('Edit-Submit emittiert updated und close', async () => {
+    axios.put.mockResolvedValueOnce({ data: { share: sampleShare } })
+    const w = factory({ editShare: sampleShare })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(w.emitted('updated')).toBeTruthy()
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('Edit-Submit sendet recursive + depth', async () => {
+    axios.put.mockResolvedValueOnce({ data: { share: sampleShare } })
+    const w = factory({ editShare: sampleShare, recursionEnabled: true })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    const body = axios.put.mock.calls[0][1]
+    expect(body.recursive).toBe(true)
+    expect(body.depth).toBe(2)
+  })
+
+  // ── Path-Blur Re-Resolve (Sarah-Use-Case) ────────────────────────────────
+
+  it('Edit-Mode: Path-Blur bei recursionEnabled löst Re-Resolve aus Settings aus', async () => {
+    // localStorage leer → Settings-Default greift
+    localStorage.clear()
+    const w = factory({
+      editShare: { ...sampleShare, recursive: true, depth: 2 },
+      recursionEnabled: true,
+      recursiveDefault: false,
+      recursiveDefaultDepth: 0,
+    })
+    // Initial: aus Share, recursive=true, depth=2
+    expect(w.find('[data-testid="recursive"]').element.checked).toBe(true)
+
+    // Pfad ändern + blur → Defaults aus Settings übernehmen (false, 0)
+    const pathInput = w.findAll('input.sr-share-modal__input[type="text"]')[0]
+    await pathInput.setValue('/AnderesFolder')
+    await pathInput.trigger('blur')
+    expect(w.find('[data-testid="recursive"]').element.checked).toBe(false)
+  })
+
+  it('Edit-Mode: Path-Blur ohne recursionEnabled hat keinen Effekt', async () => {
+    const w = factory({
+      editShare: { ...sampleShare, recursive: true, depth: 2 },
+      recursionEnabled: false,
+    })
+    const pathInput = w.findAll('input.sr-share-modal__input[type="text"]')[0]
+    await pathInput.setValue('/Anders')
+    await pathInput.trigger('blur')
+    // Recursive-Feld ist gar nicht gerendert, aber form.recursive bleibt true
+    // (kein Reset) — wird beim Submit weiterhin true sein
+    axios.put.mockResolvedValueOnce({ data: { share: sampleShare } })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(axios.put.mock.calls[0][1].recursive).toBe(true)
+  })
 })

--- a/tests/js/folderRecursiveState.spec.js
+++ b/tests/js/folderRecursiveState.spec.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  readFolderState,
+  writeFolderState,
+  clearFolderState,
+  clearAllFolderStates,
+} from '../../src/utils/folderRecursiveState.js'
+
+describe('folderRecursiveState', () => {
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  // ── Read/Write Roundtrip ──────────────────────────────────────────────────
+
+  it('liefert null für nicht gespeicherten Pfad', () => {
+    expect(readFolderState('/Photos/2026')).toBeNull()
+  })
+
+  it('Roundtrip: write dann read liefert dieselben Werte', () => {
+    writeFolderState('/Photos/2026', true, 2)
+    expect(readFolderState('/Photos/2026')).toEqual({ recursive: true, depth: 2 })
+  })
+
+  it('verschiedene Pfade sind unabhängig', () => {
+    writeFolderState('/A', true, 1)
+    writeFolderState('/B', false, 3)
+    expect(readFolderState('/A')).toEqual({ recursive: true, depth: 1 })
+    expect(readFolderState('/B')).toEqual({ recursive: false, depth: 3 })
+  })
+
+  it('Re-Write überschreibt vorherigen Wert', () => {
+    writeFolderState('/X', true, 1)
+    writeFolderState('/X', false, 4)
+    expect(readFolderState('/X')).toEqual({ recursive: false, depth: 4 })
+  })
+
+  // ── Clear ──────────────────────────────────────────────────────────────────
+
+  it('clearFolderState entfernt den Eintrag', () => {
+    writeFolderState('/Y', true, 2)
+    clearFolderState('/Y')
+    expect(readFolderState('/Y')).toBeNull()
+  })
+
+  it('clearAllFolderStates löscht alle Einträge', () => {
+    writeFolderState('/A', true, 1)
+    writeFolderState('/B', true, 2)
+    clearAllFolderStates()
+    expect(readFolderState('/A')).toBeNull()
+    expect(readFolderState('/B')).toBeNull()
+  })
+
+  // ── Validation gegen kaputte Daten ────────────────────────────────────────
+
+  it('clamped Depth auf 0-4 beim Schreiben', () => {
+    writeFolderState('/A', true, 99)
+    expect(readFolderState('/A').depth).toBe(4)
+    writeFolderState('/A', true, -3)
+    expect(readFolderState('/A').depth).toBe(0)
+  })
+
+  it('coerced recursive zu Boolean', () => {
+    writeFolderState('/A', 'yes', 2)
+    expect(readFolderState('/A').recursive).toBe(true)
+    writeFolderState('/B', null, 2)
+    expect(readFolderState('/B').recursive).toBe(false)
+  })
+
+  it('liefert sinnvolle Defaults bei manipulierten LocalStorage-Daten', () => {
+    // Manuell kaputten Eintrag injizieren
+    localStorage.setItem('starrate_folder_recursive_v1',
+      JSON.stringify({ '/X': { recursive: 'truthy-string', depth: 'two' } }))
+    const state = readFolderState('/X')
+    expect(state.recursive).toBe(false)  // strikt true erwartet
+    expect(state.depth).toBe(0)          // out-of-range fällt auf 0
+  })
+
+  it('liefert null bei kaputtem JSON in LocalStorage', () => {
+    localStorage.setItem('starrate_folder_recursive_v1', '{not valid json')
+    expect(readFolderState('/Any')).toBeNull()
+  })
+
+  // ── Edge Cases ─────────────────────────────────────────────────────────────
+
+  it('ignoriert leeren oder fehlenden Pfad bei write', () => {
+    writeFolderState('', true, 2)
+    writeFolderState(null, true, 2)
+    writeFolderState(undefined, true, 2)
+    expect(readFolderState('')).toBeNull()
+  })
+
+  it('ignoriert leeren Pfad bei read', () => {
+    expect(readFolderState('')).toBeNull()
+    expect(readFolderState(null)).toBeNull()
+    expect(readFolderState(undefined)).toBeNull()
+  })
+
+  // ── LRU-Eviction (Cap auf 50 Einträge) ────────────────────────────────────
+
+  it('hält max 50 Einträge — der älteste wird beim 51. Write rausgeworfen', () => {
+    for (let i = 0; i < 50; i++) {
+      writeFolderState(`/folder${i}`, true, i % 5)
+    }
+    // Alle 50 da
+    expect(readFolderState('/folder0')).not.toBeNull()
+    expect(readFolderState('/folder49')).not.toBeNull()
+
+    // Neuer Eintrag → /folder0 muss raus (ältester)
+    writeFolderState('/folder50', true, 1)
+    expect(readFolderState('/folder0')).toBeNull()
+    expect(readFolderState('/folder49')).not.toBeNull()
+    expect(readFolderState('/folder50')).not.toBeNull()
+  })
+
+  it('Re-Write eines existierenden Eintrags schiebt ihn ans Ende der Order', () => {
+    for (let i = 0; i < 50; i++) {
+      writeFolderState(`/folder${i}`, true, i % 5)
+    }
+    // /folder0 jetzt aktualisieren — sollte ans Ende rutschen
+    writeFolderState('/folder0', true, 4)
+    // Neuer Eintrag /folder50 → der jetzt ÄLTESTE (/folder1) muss raus,
+    // /folder0 bleibt drin weil neu insertiert.
+    writeFolderState('/folder50', true, 0)
+    expect(readFolderState('/folder1')).toBeNull()
+    expect(readFolderState('/folder0')).not.toBeNull()
+    expect(readFolderState('/folder50')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## v1.3.1

Two new features building on the recursive folder view from v1.3.0, plus a ShareList refactor that makes share configuration cleaner.

### What's new for users

**Per-folder memory for recursive view** — when you flip recursive on (or change the depth) for a folder, the next time you visit that same folder it remembers your choice. Works without URL params, without changing personal settings — just stays per folder. Cap at 50 folders, oldest rotates out.

**Per-share recursive view** — when creating or editing a share, you can now choose whether the guest sees a recursive view (all images from subfolders in one grid) and the group depth. The share carries its own configuration; the photographer's personal setting only seeds the defaults when the share is created. Guests have no way to override — they see exactly what the photographer chose.

**Edit existing shares** — instead of multiple small toggle buttons in the share list, each share now has a pencil icon that opens the same modal you used to create it, prefilled with the current values. Change permissions, password, recursive view, or even the shared folder path — all in one place. The status of each share (password set, pick allowed, export allowed, etc.) is still visible at a glance via small read-only icons in the share row.

**Faster guest revisits** — guest thumbnails and previews are now cached in the browser for 7 days. When the same recipient comes back for a second rating round, the gallery loads instantly from local cache. ETag revalidation kicks in if the underlying files have changed.

**Smarter prefill when changing share path** — if you edit a share and change the folder path, the recursive settings reset to your default for the new folder (matching what you'd see opening that folder yourself). One less manual step for "I want to repurpose this share for a different shoot".

**Compact share list layout** — folder path and recipient name share one line now (separated with `—`), saving vertical space in the share list.

### Notes for testers

- The master switch in personal settings (`Recursive view enabled`) still gates everything — defaults to off for existing users.
- Old shares (created before v1.3.1) are treated as non-recursive automatically — no migration needed.
- Browser cache lasts 7 days; if you want to test changes immediately, hard-reload (Ctrl+F5) bypasses the cache.

### Notes on architecture

The guest-side recursive listing is a deliberate code copy of the owner-side listing (with explicit security comment), kept that way to make any divergence loud in code review — a drift between the two would be a privilege-escalation risk.

Closes nothing standalone but extends what was delivered for #35.