### PR TITLE
feat(loupe): Slideshow with S-toggle, loop and user setting

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,7 +52,7 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 - Englisch und Deutsch
     ]]></description>
 
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <licence>agpl</licence>
 
     <author mail="starrate@merlin1.de" homepage="https://github.com/merlin1de/starrate">

--- a/lib/Settings/UserSettings.php
+++ b/lib/Settings/UserSettings.php
@@ -17,6 +17,11 @@ class UserSettings implements ISettings
 {
     private const APP_ID = 'starrate';
 
+    /** Erlaubte Diashow-Intervalle in Sekunden. Spiegel zu src/utils/slideshow.js. */
+    public const SLIDESHOW_INTERVALS = [1, 2, 3, 4, 5, 7, 10, 15, 30];
+
+    public const SLIDESHOW_DEFAULT_SEC = 4;
+
     public function __construct(
         private readonly IConfig      $config,
         private readonly IUserSession $userSession,
@@ -69,6 +74,8 @@ class UserSettings implements ISettings
             'recursion_enabled'        => $this->getBool($userId, 'recursion_enabled', false),
             'recursive_default'        => $this->getBool($userId, 'recursive_default', false),
             'recursive_default_depth'  => $this->getInt($userId, 'recursive_default_depth', 0),
+            // Diashow-Intervall in Sekunden. Siehe Loupe „S“-Toggle.
+            'slideshow_interval'       => $this->getInt($userId, 'slideshow_interval', self::SLIDESHOW_DEFAULT_SEC),
         ];
     }
 
@@ -85,6 +92,7 @@ class UserSettings implements ISettings
             'show_filename', 'show_rating_overlay',
             'show_color_overlay', 'grid_columns', 'enable_pick_ui', 'write_xmp', 'comments_enabled',
             'recursion_enabled', 'recursive_default', 'recursive_default_depth',
+            'slideshow_interval',
         ];
 
         foreach ($data as $key => $value) {
@@ -129,6 +137,7 @@ class UserSettings implements ISettings
             'default_sort_order' => $this->assertIn($key, $value, ['asc', 'desc']),
             'grid_columns' => $this->assertIn($key, $value, ['auto', '2', '3', '4', '5', '6', '8']),
             'recursive_default_depth' => $this->assertIntRange($key, $value, 0, 4),
+            'slideshow_interval' => $this->assertIn($key, (int) $value, self::SLIDESHOW_INTERVALS),
             'show_filename', 'show_rating_overlay', 'show_color_overlay',
             'enable_pick_ui', 'write_xmp', 'comments_enabled',
             'recursion_enabled', 'recursive_default' => null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrate",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "description": "Professionelles Foto-Bewertungs- und Lightroom-Sync-Tool für Nextcloud",
   "scripts": {

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -96,6 +96,39 @@
     <!-- Untere Overlay: Dateiname + Rating + Farbe -->
     <Transition name="slide-up">
       <div class="sr-loupe__footer" v-show="showControls">
+        <!-- Diashow: Play/Pause + (im Play-Modus) Intervall-Dropdown -->
+        <div class="sr-loupe__footer-slideshow">
+          <button
+            class="sr-loupe__slideshow-btn"
+            :class="{ 'sr-loupe__slideshow-btn--active': playing }"
+            type="button"
+            :title="playing ? t('starrate', 'Diashow pausieren (S)') : t('starrate', 'Diashow starten (S)')"
+            :aria-label="playing ? t('starrate', 'Diashow pausieren') : t('starrate', 'Diashow starten')"
+            :aria-pressed="playing"
+            @click="togglePlay"
+          >
+            <svg v-if="!playing" class="sr-loupe__slideshow-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <polygon points="6,4 20,12 6,20" />
+            </svg>
+            <svg v-else class="sr-loupe__slideshow-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <rect x="6" y="4" width="4" height="16"/>
+              <rect x="14" y="4" width="4" height="16"/>
+            </svg>
+          </button>
+          <Transition name="fade">
+            <select
+              v-if="playing"
+              class="sr-loupe__slideshow-select"
+              :value="slideshowSec"
+              :title="t('starrate', 'Diashow-Intervall')"
+              :aria-label="t('starrate', 'Diashow-Intervall in Sekunden')"
+              @change="changeInterval(parseInt($event.target.value, 10))"
+            >
+              <option v-for="s in SLIDESHOW_INTERVALS" :key="s" :value="s">{{ s }} s</option>
+            </select>
+          </Transition>
+        </div>
+
         <div class="sr-loupe__footer-left">
           <span class="sr-loupe__filename">{{ currentImage?.name }}</span>
           <span class="sr-loupe__index">{{ currentIndex + 1 }} / {{ images.length }}</span>
@@ -227,12 +260,18 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, watchEffect, onMounted, onUnmounted, nextTick } from 'vue'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import RatingStars from './RatingStars.vue'
 import ColorLabel from './ColorLabel.vue'
+import {
+  SLIDESHOW_INTERVALS,
+  SLIDESHOW_DEFAULT_SEC,
+  SLIDESHOW_GUEST_LS_KEY,
+  isValidSlideshowInterval,
+} from '../utils/slideshow.js'
 
 const props = defineProps({
   images: {
@@ -266,6 +305,16 @@ const props = defineProps({
   },
   /** Owner-Modus: Kommentare global aktiviert */
   commentsEnabledOwner: {
+    type: Boolean,
+    default: false,
+  },
+  /** Diashow-Intervall in Sekunden (User-Setting). Loupe-lokale Änderungen sind ephemer. */
+  slideshowInterval: {
+    type: Number,
+    default: SLIDESHOW_DEFAULT_SEC,
+  },
+  /** Gast-Modus: localStorage-Backup statt User-Setting. */
+  guestMode: {
     type: Boolean,
     default: false,
   },
@@ -305,6 +354,11 @@ let   lastTouchEnd = 0
 
 // Bildübergang
 const transitionName = ref('slide-right')
+
+// Diashow (Konstanten siehe utils/slideshow.js)
+const playing      = ref(false)
+const slideshowSec = ref(SLIDESHOW_DEFAULT_SEC)
+let   slideshowTimer = null
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -358,6 +412,82 @@ function navigate(delta) {
 
   // Rating vom Server nachladen (Sync-Light für Multi-User)
   props.onRefreshRating?.(props.images[newIdx])
+}
+
+// ─── Diashow ─────────────────────────────────────────────────────────────────
+
+function clearSlideshowTimer() {
+  if (slideshowTimer) {
+    clearTimeout(slideshowTimer)
+    slideshowTimer = null
+  }
+}
+
+function scheduleNext() {
+  clearSlideshowTimer()
+  if (!playing.value) return
+  if (props.images.length === 0) {
+    playing.value = false
+    return
+  }
+  slideshowTimer = setTimeout(() => {
+    if (!playing.value) return
+    if (currentIndex.value < props.images.length - 1) {
+      navigate(1)
+    } else {
+      // Loop zurück zum ersten Bild — Slideshow läuft endlos.
+      transitionName.value = 'slide-left'
+      currentIndex.value   = 0
+      resetZoom()
+      emit('index-change', 0)
+      props.onRefreshRating?.(props.images[0])
+    }
+  }, slideshowSec.value * 1000)
+}
+
+function togglePlay() {
+  // Bei offenem Comment-Sheet kein Toggle (Sicherheitsnetz neben dem Sheet-Guard
+  // in onKeydown — schützt z.B. Click auf Play während Sheet offen ist).
+  if (commentSheetOpen.value) return
+  playing.value = !playing.value
+}
+
+function changeInterval(sec) {
+  if (!isValidSlideshowInterval(sec)) return
+  slideshowSec.value = sec
+  if (props.guestMode) {
+    try { localStorage.setItem(SLIDESHOW_GUEST_LS_KEY, String(sec)) } catch {}
+  }
+}
+
+watch(playing, (v) => {
+  if (v) scheduleNext()
+  else   clearSlideshowTimer()
+})
+
+watch(currentIndex, () => {
+  if (playing.value) scheduleNext()
+})
+
+watch(slideshowSec, () => {
+  if (playing.value) scheduleNext()
+})
+
+// Owner-Modus: Prop ist single source of truth — watchEffect spiegelt
+// Initial- und Update-Pfad konsistent. Gäste werden im onMounted aus
+// localStorage initialisiert; ein Prop-Update kann sie nicht mehr überschreiben.
+watchEffect(() => {
+  if (props.guestMode) return
+  if (isValidSlideshowInterval(props.slideshowInterval)) {
+    slideshowSec.value = props.slideshowInterval
+  }
+})
+
+// Tab-Visibility: pausiert die Slideshow wenn der Tab in den Hintergrund geht.
+// Browser throtteln setTimeout im Hintergrund (Chrome ab 1 min hart) — ohne
+// Pause käme bei Rückkehr eine Bilderlawine.
+function onVisibilityChange() {
+  if (document.hidden && playing.value) playing.value = false
 }
 
 const preloadedUrls = new Set()
@@ -592,6 +722,11 @@ function onKeydown(e) {
     return
   }
 
+  // Bei offenem Comment-Sheet alle Shortcuts deaktivieren — schützt nicht
+  // nur die Textarea-Eingabe (TEXTAREA-Guard greift dafür ohnehin), sondern
+  // auch Klicks außerhalb des Textfelds bei offenem Sheet.
+  if (commentSheetOpen.value) return
+
   // Eingabefelder in Ruhe lassen
   const tag = document.activeElement?.tagName
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
@@ -635,6 +770,11 @@ function onKeydown(e) {
     case ' ':
       e.preventDefault()
       resetZoom()
+      break
+
+    case 's': case 'S':
+      e.preventDefault()
+      togglePlay()
       break
 
     // Bewertungen
@@ -832,6 +972,9 @@ function loadComment(fileId) {
 }
 
 async function openCommentSheet() {
+  // Sheet öffnen pausiert die Slideshow — sonst wechselt das Bild unter dem
+  // offenen Sheet weg und der User kommentiert das falsche Bild.
+  playing.value = false
   commentStatus.value = ''
   // Sicherstellen dass Kommentar geladen ist (kein Doppel-Request dank commentLoaded-Flag)
   if (!commentLoaded.value) {
@@ -919,18 +1062,29 @@ watch(currentImage, (img) => {
 
 onMounted(() => {
   document.addEventListener('keydown', onKeydown)
+  document.addEventListener('visibilitychange', onVisibilityChange)
   resetControlsTimer()
   // Kommentar für das erste Bild laden (ohne Watch-immediate um Jiggling zu vermeiden)
   if (props.allowComment || props.commentsEnabledOwner) {
     loadComment(currentImage.value?.id)
   }
+  // Gast-Modus: localStorage-Backup für Slideshow-Intervall einlesen.
+  // Im Owner-Modus übernimmt das der watchEffect auf props.slideshowInterval.
+  if (props.guestMode) {
+    try {
+      const v = parseInt(localStorage.getItem(SLIDESHOW_GUEST_LS_KEY) || '', 10)
+      if (isValidSlideshowInterval(v)) slideshowSec.value = v
+    } catch {}
+  }
 })
 
 onUnmounted(() => {
   document.removeEventListener('keydown', onKeydown)
+  document.removeEventListener('visibilitychange', onVisibilityChange)
   clearTimeout(hideControlsTimer)
   clearTimeout(previewRetryTimer)
   clearTimeout(commentStatusTimer)
+  clearSlideshowTimer()
 })
 
 watch(() => props.initialIndex, idx => {
@@ -1173,6 +1327,55 @@ watch(() => props.initialIndex, idx => {
   flex-shrink: 0;
 }
 
+/* ── Diashow Footer-Block ─────────────────────────────────────────────────── */
+.sr-loupe__footer-slideshow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.sr-loupe__slideshow-btn {
+  background: transparent;
+  border: none;
+  color: #a8a8b8;
+  cursor: pointer;
+  padding: 0 4px;
+  display: flex;
+  align-items: center;
+  transition: color 150ms;
+}
+
+.sr-loupe__slideshow-btn:hover         { color: #d4d4d8; }
+.sr-loupe__slideshow-btn--active       { color: #d4d4d8; }
+.sr-loupe__slideshow-icon              { width: 22px; height: 22px; }
+
+.sr-loupe__slideshow-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='%23bbbbbb' d='M0 0l5 6 5-6z'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  color: #d4d4d8;
+  border: 1px solid #44446a;
+  border-radius: 4px;
+  padding: 2px 18px 2px 6px;
+  font-size: 12px;
+  outline: none;
+  cursor: pointer;
+}
+.sr-loupe__slideshow-select:focus      { border-color: #e94560; }
+
+/* Desktop: Slideshow-Block direkt links neben Comment-Button (in der Mitte) */
+@media (pointer: fine) {
+  .sr-loupe__footer-left      { order: 1; }
+  .sr-loupe__footer-slideshow { order: 2; }
+  .sr-loupe__comment-btn      { order: 3; }
+  .sr-loupe__footer-center    { order: 4; }
+  .sr-loupe__footer-right     { order: 5; }
+}
+
 .sr-loupe__pick-btn {
   width: 28px;
   height: 28px;
@@ -1316,6 +1519,13 @@ watch(() => props.initialIndex, idx => {
   }
   .sr-loupe__comment-icon { width: 26px; height: 26px; }
   .sr-loupe__comment-label { display: none; }
+  /* Diashow als dritter Block in Zeile 2, ganz links: [Play] [File] [Comment] */
+  .sr-loupe__footer-slideshow {
+    order: 2;
+    align-self: center;
+  }
+  .sr-loupe__slideshow-icon { width: 26px; height: 26px; }
+  .sr-loupe__slideshow-select { font-size: 13px; padding: 3px 6px; }
 }
 
 /* ── Kommentar Bottom Sheet ────────────────────────────────────────────────── */

--- a/src/utils/slideshow.js
+++ b/src/utils/slideshow.js
@@ -1,0 +1,19 @@
+/**
+ * Diashow-Konstanten — single source of truth für Frontend.
+ * Backend-Spiegel: lib/Settings/UserSettings.php::SLIDESHOW_INTERVALS
+ */
+
+export const SLIDESHOW_INTERVALS = [1, 2, 3, 4, 5, 7, 10, 15, 30]
+
+export const SLIDESHOW_DEFAULT_SEC = 4
+
+/** localStorage-Key, NUR für Gast-Modus (eigener Namespace, kein Owner-Konflikt). */
+export const SLIDESHOW_GUEST_LS_KEY = 'starrate_guest_slideshow_interval'
+
+/**
+ * @param {*} v Roher Wert (z.B. aus localStorage, URL, Form)
+ * @returns {boolean}
+ */
+export function isValidSlideshowInterval(v) {
+  return typeof v === 'number' && SLIDESHOW_INTERVALS.includes(v)
+}

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -141,6 +141,8 @@
         :allow-comment="settings.comments_enabled || allowComment"
         :comment-api="commentApi"
         :comments-enabled-owner="settings.comments_enabled"
+        :slideshow-interval="settings.slideshow_interval ?? 4"
+        :guest-mode="guestMode"
         @rate="onRate"
         @close="mode = 'grid'"
         @index-change="currentIndex = $event"
@@ -324,6 +326,7 @@ const settings = ref({
   recursion_enabled:         false,
   recursive_default:         false,
   recursive_default_depth:   0,
+  slideshow_interval:        4,
 })
 const subFolders   = ref([])
 const currentIndex = ref(0)

--- a/src/views/SettingsPanel.vue
+++ b/src/views/SettingsPanel.vue
@@ -122,6 +122,23 @@
       </p>
     </div>
 
+    <div class="sr-settings__group">
+      <h3 class="sr-settings__heading">{{ t('starrate', 'Diashow') }}</h3>
+
+      <div class="sr-settings__row">
+        <label class="sr-settings__label">{{ t('starrate', 'Intervall') }}</label>
+        <div class="sr-settings__control">
+          <select v-model.number="form.slideshow_interval" class="sr-settings__select" @change="autosave">
+            <option v-for="s in SLIDESHOW_INTERVALS" :key="s" :value="s">{{ s }} s</option>
+          </select>
+        </div>
+      </div>
+
+      <p class="sr-settings__hint">
+        {{ t('starrate', 'Zeit pro Bild in der Diashow. Start/Pause mit Taste S in der Lupenansicht.') }}
+      </p>
+    </div>
+
     <!-- Status -->
     <Transition name="sr-fade">
       <span v-if="status" class="sr-settings__status" :class="`sr-settings__status--${status}`">
@@ -137,6 +154,7 @@ import { reactive, ref } from 'vue'
 import { t } from '@nextcloud/l10n'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
+import { SLIDESHOW_INTERVALS, SLIDESHOW_DEFAULT_SEC } from '../utils/slideshow.js'
 
 const props = defineProps({
   initial: { type: Object, default: () => ({}) },
@@ -155,6 +173,7 @@ const DEFAULTS = {
   recursion_enabled:         false,
   recursive_default:         false,
   recursive_default_depth:   0,
+  slideshow_interval:        SLIDESHOW_DEFAULT_SEC,
 }
 
 const form   = reactive({ ...DEFAULTS, ...props.initial })

--- a/tests/Unit/Settings/UserSettingsTest.php
+++ b/tests/Unit/Settings/UserSettingsTest.php
@@ -322,6 +322,63 @@ class UserSettingsTest extends TestCase
         return [['auto'], ['2'], ['3'], ['4'], ['5'], ['6'], ['8']];
     }
 
+    // ─── Slideshow-Intervall ─────────────────────────────────────────────────
+
+    public function testGetSettingsReturnsSlideshowDefault(): void
+    {
+        $this->config->method('getUserValue')
+            ->willReturnCallback(fn($uid, $app, $key, $default) => $default);
+
+        $result = $this->settings->getSettings(self::USER_ID);
+        $this->assertSame(4, $result['slideshow_interval']);
+    }
+
+    public function testGetSettingsParsesSlideshowAsInt(): void
+    {
+        $this->config->method('getUserValue')
+            ->willReturnCallback(function ($uid, $app, $key, $default) {
+                return $key === 'slideshow_interval' ? '7' : $default;
+            });
+
+        $result = $this->settings->getSettings(self::USER_ID);
+        $this->assertSame(7, $result['slideshow_interval']);
+    }
+
+    /** @dataProvider validSlideshowIntervalProvider */
+    public function testSaveSettingsAcceptsAllValidSlideshowIntervals(int $sec): void
+    {
+        $saved = [];
+        $this->config->method('setUserValue')
+            ->willReturnCallback(function ($uid, $app, $key, $val) use (&$saved) {
+                $saved[$key] = $val;
+            });
+        $this->settings->saveSettings(self::USER_ID, ['slideshow_interval' => $sec]);
+        $this->assertSame((string) $sec, $saved['slideshow_interval']);
+    }
+
+    public static function validSlideshowIntervalProvider(): array
+    {
+        return [[1], [2], [3], [4], [5], [7], [10], [15], [30]];
+    }
+
+    public function testSaveSettingsThrowsForInvalidSlideshowInterval(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->settings->saveSettings(self::USER_ID, ['slideshow_interval' => 6]);
+    }
+
+    public function testSaveSettingsThrowsForOutOfRangeSlideshowInterval(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->settings->saveSettings(self::USER_ID, ['slideshow_interval' => 99]);
+    }
+
+    public function testSaveSettingsThrowsForNonNumericSlideshowInterval(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->settings->saveSettings(self::USER_ID, ['slideshow_interval' => 'fast']);
+    }
+
     // ─── getSection / getPriority ────────────────────────────────────────────
 
     public function testGetSectionReturnsStarrate(): void

--- a/tests/js/ZoomView.spec.js
+++ b/tests/js/ZoomView.spec.js
@@ -781,3 +781,175 @@ describe('LoupeView – Zoom & Navigation', () => {
   })
 
 })
+
+// ─── Diashow ──────────────────────────────────────────────────────────────────
+
+describe('LoupeView – Diashow', () => {
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('zeigt Play-Icon, kein Dropdown im Ruhezustand', () => {
+    const w = factory({ slideshowInterval: 4 })
+    expect(w.find('.sr-loupe__slideshow-btn').exists()).toBe(true)
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(false)
+    expect(w.find('.sr-loupe__slideshow-select').exists()).toBe(false)
+    // Play-SVG = polygon
+    expect(w.find('.sr-loupe__slideshow-btn polygon').exists()).toBe(true)
+  })
+
+  it('Klick auf Play toggelt zu Pause + zeigt Dropdown', async () => {
+    const w = factory({ slideshowInterval: 4 })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(true)
+    expect(w.find('.sr-loupe__slideshow-select').exists()).toBe(true)
+    // Pause-SVG = zwei rects
+    expect(w.find('.sr-loupe__slideshow-btn rect').exists()).toBe(true)
+  })
+
+  it('Tastatur "s" toggelt Play/Pause', async () => {
+    const w = factory({ slideshowInterval: 4 })
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 's' }))
+    await w.vm.$nextTick()
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(true)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'S' }))
+    await w.vm.$nextTick()
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(false)
+  })
+
+  it('advanced nach Intervall zum nächsten Bild', async () => {
+    vi.useFakeTimers()
+    const w = factory({ slideshowInterval: 2 })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    expect(w.emitted('index-change')).toBeFalsy()
+    vi.advanceTimersByTime(2000)
+    await flushPromises()
+    expect(w.emitted('index-change')?.[0]).toEqual([1])
+    vi.useRealTimers()
+  })
+
+  it('loopt zum ersten Bild zurück und läuft weiter', async () => {
+    vi.useFakeTimers()
+    const w = factory({ slideshowInterval: 1, initialIndex: 2 })   // letzter Index
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(true)
+    // Erster Tick: loopt zum Anfang
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(w.emitted('index-change')?.[0]).toEqual([0])
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(true)
+    // Zweiter Tick: weiter zu Index 1
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(w.emitted('index-change')?.[1]).toEqual([1])
+    vi.useRealTimers()
+  })
+
+  it('stoppt sofort wenn images leer ist', async () => {
+    vi.useFakeTimers()
+    const w = mount(LoupeView, { props: { images: [], initialIndex: 0 } })
+    wrappers.push(w)
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    await flushPromises()
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it('Pfeil-rechts während Play → resettet Timer', async () => {
+    vi.useFakeTimers()
+    const w = factory({ slideshowInterval: 3 })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    vi.advanceTimersByTime(1500)                        // halber Intervall
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
+    await flushPromises()
+    expect(w.emitted('index-change')?.[0]).toEqual([1])
+    // Nach Reset: weitere 1500ms reichen NICHT für nächsten Advance (Timer startete bei Index 1 neu)
+    vi.advanceTimersByTime(1500)
+    await flushPromises()
+    expect(w.emitted('index-change')?.length).toBe(1)
+    vi.advanceTimersByTime(1500)
+    await flushPromises()
+    expect(w.emitted('index-change')?.[1]).toEqual([2])
+    vi.useRealTimers()
+  })
+
+  it('Dropdown-Change im Owner-Modus: kein localStorage-Write', async () => {
+    const w = factory({ slideshowInterval: 4, guestMode: false })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    const select = w.find('.sr-loupe__slideshow-select')
+    await select.setValue('7')
+    expect(localStorage.getItem('starrate_guest_slideshow_interval')).toBeNull()
+  })
+
+  it('Dropdown-Change im Gast-Modus: schreibt localStorage', async () => {
+    const w = factory({ slideshowInterval: 4, guestMode: true })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    const select = w.find('.sr-loupe__slideshow-select')
+    await select.setValue('7')
+    expect(localStorage.getItem('starrate_guest_slideshow_interval')).toBe('7')
+  })
+
+  it('Mount im Gast-Modus liest localStorage', async () => {
+    localStorage.setItem('starrate_guest_slideshow_interval', '10')
+    const w = factory({ slideshowInterval: 4, guestMode: true })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    const select = w.find('.sr-loupe__slideshow-select')
+    expect(select.element.value).toBe('10')
+  })
+
+  it('Mount im Gast-Modus mit ungültigem localStorage-Wert: Default 4 bleibt', async () => {
+    localStorage.setItem('starrate_guest_slideshow_interval', '999')
+    const w = factory({ slideshowInterval: 4, guestMode: true })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    const select = w.find('.sr-loupe__slideshow-select')
+    expect(select.element.value).toBe('4')
+  })
+
+  it('onUnmounted: kein Tick nach Unmount', async () => {
+    vi.useFakeTimers()
+    const w = factory({ slideshowInterval: 1 })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    w.unmount()
+    // Aus wrappers entfernen, damit afterEach nicht doppelt unmounted
+    wrappers.pop()
+    expect(() => vi.advanceTimersByTime(2000)).not.toThrow()
+    vi.useRealTimers()
+  })
+
+  it('Owner-Modus: Prop-Update spiegelt sich in slideshowSec', async () => {
+    const w = factory({ slideshowInterval: 4, guestMode: false })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    expect(w.find('.sr-loupe__slideshow-select').element.value).toBe('4')
+    await w.setProps({ slideshowInterval: 15 })
+    expect(w.find('.sr-loupe__slideshow-select').element.value).toBe('15')
+  })
+
+  it('Gast-Modus: Prop-Update überschreibt localStorage-Wert NICHT', async () => {
+    localStorage.setItem('starrate_guest_slideshow_interval', '10')
+    const w = factory({ slideshowInterval: 4, guestMode: true })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    expect(w.find('.sr-loupe__slideshow-select').element.value).toBe('10')
+    await w.setProps({ slideshowInterval: 15 })
+    expect(w.find('.sr-loupe__slideshow-select').element.value).toBe('10')
+  })
+
+  it('Comment-Sheet öffnen pausiert die Slideshow', async () => {
+    const w = factory({ slideshowInterval: 4, commentsEnabledOwner: true })
+    await w.find('.sr-loupe__slideshow-btn').trigger('click')
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(true)
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(false)
+  })
+
+  it('"s"-Taste bei offenem Comment-Sheet wird ignoriert', async () => {
+    const w = factory({ slideshowInterval: 4, commentsEnabledOwner: true })
+    await w.find('.sr-loupe__comment-btn').trigger('click')
+    await flushPromises()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 's' }))
+    await w.vm.$nextTick()
+    expect(w.find('.sr-loupe__slideshow-btn--active').exists()).toBe(false)
+  })
+
+})


### PR DESCRIPTION
## Summary
- Adds an auto-advance slideshow to the loupe view: Play/Pause button + interval dropdown in the footer (next to the comment button on desktop, third block in the second row on mobile).
- Toggle with `S` (synced to FlashView's keybinding). Cursor (←/→) and touch swipe react instantly and restart the timer. At the end the slideshow loops back to the first image.
- New user setting `slideshow_interval` with values `[1, 2, 3, 4, 5, 7, 10, 15, 30]` seconds (default 4), exposed in the Personal → StarRate → Diashow section.
- The dropdown inside the loupe is ephemeral (current session only) — settings page is the canonical place to change the default. Guests don't have a settings page, so they get a `localStorage` backup under `starrate_guest_slideshow_interval` (separate namespace from any owner session sharing the browser).
- Defensive UX: opening the comment sheet pauses the slideshow; all loupe shortcuts are inactive while the comment sheet is open; `document.visibilitychange` pauses on background tabs to avoid Chrome's setTimeout-throttle "image avalanche" on return.

Closes part of #25.

## Test plan
- [ ] Vitest passes locally — 418 tests including 16 new slideshow tests (`tests/js/ZoomView.spec.js`).
- [ ] PHPUnit passes — 6 new tests in `tests/Unit/Settings/UserSettingsTest.php` covering valid intervals, defaults, and validation rejects.
- [ ] Open the loupe → press `S` → image auto-advances after the configured interval.
- [ ] Reach the last image → slideshow loops to image 1 and continues.
- [ ] Change dropdown to 2 s during play → bilder wechseln nun alle 2 s.
- [ ] Close + reopen loupe → dropdown is back to the saved user setting (loupe value was ephemeral).
- [ ] Mobile (375×667): footer second row shows `[Play] [Filename + counter] [Comment]` centered.
- [ ] Open comment sheet during play → slideshow pauses; pressing `S` while sheet is open does nothing.
- [ ] Switch tab during play → slideshow pauses (no avalanche on return).
- [ ] Guest share in same browser as owner: dropdown change writes `starrate_guest_slideshow_interval` only — owner setting unaffected.