### PR TITLE
feat(xmp): photoshop:LabelColor parallel + xmpDM Pick/Reject + DE/EN label language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### EN
+
+**New features**
+- **Color rating compatible with: Lightroom (DE) / Bridge / digiKam** (#69, #70) — new personal setting that controls the language of `xmp:Label`. With "Lightroom (German localization)" StarRate writes `xmp:Label="Rot"` etc. so a German LRC matches its native label set strings instead of falling through to "Custom" with a white flag. With "Bridge / digiKam / English tools" it writes `xmp:Label="Red"` etc. Default derives from the NC user UI language (`de_*` → DE, otherwise EN), so German users get a working LRC import out of the box. The companion `photoshop:LabelColor` field stays lowercase English regardless — that's universal and drives the LR color stripe.
+- **Pick / Reject is now written into XMP** (#70) — previously stored only in NC tags. Bridge/LRC standard format: pick → `xmpDM:pick="1"` + `xmpDM:good="true"`, reject → `xmpDM:pick="-1"` + `xmpDM:good="false"`, none → both attributes removed. Read path is backward-compatible with the older FlashView schema (`flashView:IsPicked`/`IsRejected`); the write path actively cleans up those legacy attributes including the orphan `xmlns:flashView` namespace declaration.
+
+**Bug fixes**
+- **LR re-imports the wrong color label after editing in StarRate** (#70) — Lightroom Classic 7+ reads `photoshop:LabelColor` (lowercase EN) with priority over `xmp:Label` to derive the color stripe. StarRate previously only wrote `xmp:Label`, and the patch path did not strip a stale `photoshop:LabelColor` left behind by LR — so a re-import in LR showed the old color, ignoring the change. StarRate now writes both fields in lockstep and removes any stale `photoshop:LabelColor` before re-injecting.
+- **Grid only fills 2/3 of the viewport after navigating into a subfolder** (#71) — when SPA-navigating between folders, the header above the grid changed (subfolder pills appearing/disappearing), which moved the grid vertically without changing its own size. The existing `ResizeObserver` on the grid stayed silent and the cached `max-height` was wrong for the new layout, requiring a manual reload. Now the observer also watches the grid's wrap parent, so any header-size change re-runs the height calculation.
+
+### DE
+
+**Neue Features**
+- **Farb-Bewertungen kompatibel mit: Lightroom (DE) / Bridge / digiKam** (#69, #70) — neue persönliche Einstellung, die die Sprache von `xmp:Label` steuert. Mit „Lightroom (deutsche Lokalisierung)" schreibt StarRate `xmp:Label="Rot"` etc., damit ein deutsches LRC den nativen Label-Set-String matcht und nicht auf „Custom" mit weißer Fahne durchfällt. Mit „Bridge / digiKam / englische Tools" wird `xmp:Label="Red"` etc. geschrieben. Default leitet sich aus der NC-UI-Sprache ab (`de_*` → DE, sonst EN) — deutsche User bekommen einen funktionierenden LRC-Import direkt out of the box. Das parallele Feld `photoshop:LabelColor` bleibt unabhängig davon immer in lowercase EN — das ist universell und treibt den Farbstreifen in LR.
+- **Pick / Reject werden jetzt ins XMP geschrieben** (#70) — bislang nur als NC-Tag gespeichert. Bridge/LRC-Standardformat: Pick → `xmpDM:pick="1"` + `xmpDM:good="true"`, Reject → `xmpDM:pick="-1"` + `xmpDM:good="false"`, none → beide Attribute komplett entfernt. Der Lesepfad bleibt rückwärtskompatibel zum älteren FlashView-Schema (`flashView:IsPicked`/`IsRejected`); der Schreibpfad räumt diese Legacy-Attribute inklusive verwaister `xmlns:flashView`-Namespace-Deklaration aktiv weg.
+
+**Bugfixes**
+- **LR re-importiert die falsche Farbe nach Änderung in StarRate** (#70) — Lightroom Classic 7+ liest `photoshop:LabelColor` (lowercase EN) mit Priorität über `xmp:Label`, um den Farbstreifen abzuleiten. StarRate hat bisher nur `xmp:Label` geschrieben, und der Patch-Pfad hat ein von LR hinterlassenes `photoshop:LabelColor` nicht entfernt — beim Re-Import in LR wurde die alte Farbe angezeigt, unsere Änderung ignoriert. StarRate schreibt jetzt beide Felder parallel und räumt ein stale `photoshop:LabelColor` vor dem Re-Inject weg.
+- **Grid füllt nur 2/3 der Bildschirmhöhe nach Wechsel in einen Unterordner** (#71) — bei SPA-Navigation zwischen Ordnern änderte sich der Header oberhalb des Grids (Subfolder-Pills tauchten auf oder verschwanden), das Grid wurde vertikal verschoben, behielt aber seine eigene Größe. Der bestehende `ResizeObserver` auf dem Grid feuerte daher nicht und die gecachte `max-height` war für das neue Layout falsch — ein manueller Reload war nötig. Der Observer beobachtet jetzt zusätzlich das Wrap-Parent-Element, sodass jede Header-Größenänderung die Höhenberechnung neu auslöst.
+
 ## 1.2.11
 
 ### EN

--- a/lib/Controller/RatingController.php
+++ b/lib/Controller/RatingController.php
@@ -113,14 +113,16 @@ class RatingController extends Controller
             $this->tagService->setMetadata($fileIdStr, $data);
 
             // 2. JPEG-XMP schreiben — nur wenn JPEG und in den Einstellungen aktiviert
-            $mime = $file->getMimeType();
-            if (in_array($mime, ['image/jpeg', 'image/jpg'], true)
-                && $this->userSettings->getSettings($userId)['write_xmp']) {
+            $mime     = $file->getMimeType();
+            $settings = $this->userSettings->getSettings($userId);
+            if (in_array($mime, ['image/jpeg', 'image/jpg'], true) && $settings['write_xmp']) {
                 try {
                     $this->exifService->writeMetadata(
                         $file,
                         $data['rating'] ?? null,
                         array_key_exists('color', $data) ? ($data['color'] ?? '') : null,
+                        array_key_exists('pick', $data)  ? $data['pick']           : null,
+                        $settings['xmp_label_language'],
                     );
                 } catch (\Exception $e) {
                     $this->logger->warning("StarRate: XMP write skipped for {$fileId}: " . $e->getMessage());
@@ -191,7 +193,9 @@ class RatingController extends Controller
         $xmpWritten = 0;
         $xmpSkipped = 0;
         $details    = [];
-        $writeXmp   = $this->userSettings->getSettings($userId)['write_xmp'];
+        $settings   = $this->userSettings->getSettings($userId);
+        $writeXmp   = $settings['write_xmp'];
+        $labelLang  = $settings['xmp_label_language'];
 
         foreach ($body['fileIds'] as $rawId) {
             $fileId = (int) $rawId;
@@ -215,6 +219,8 @@ class RatingController extends Controller
                             $file,
                             $data['rating'] ?? null,
                             array_key_exists('color', $data) ? ($data['color'] ?? '') : null,
+                            array_key_exists('pick', $data)  ? $data['pick']           : null,
+                            $labelLang,
                         );
                         $xmpWritten++;
                     } catch (\Exception $e) {
@@ -265,7 +271,7 @@ class RatingController extends Controller
             $mime = $file->getMimeType();
             if (in_array($mime, ['image/jpeg', 'image/jpg'], true)
                 && $this->userSettings->getSettings($userId)['write_xmp']) {
-                $this->exifService->writeMetadata($file, 0, '');
+                $this->exifService->writeMetadata($file, 0, '', 'none');
             }
 
             return new DataResponse(['ok' => true]);

--- a/lib/Service/ExifService.php
+++ b/lib/Service/ExifService.php
@@ -15,7 +15,8 @@ use Psr\Log\LoggerInterface;
  * in den JPEG-Datenstrom eingebettet.
  *
  * Unterstützte Formate: JPEG / JPG
- * Schreibt: xmp:Rating (0–5), xmp:Label (Red/Yellow/Green/Blue/Purple)
+ * Schreibt: xmp:Rating (0–5), xmp:Label + photoshop:LabelColor,
+ *           xmpDM:pick + xmpDM:good (Pick/Reject, LRC/Bridge-kompatibel).
  */
 class ExifService
 {
@@ -39,38 +40,47 @@ class ExifService
     // ─── Öffentliche API ──────────────────────────────────────────────────────
 
     /**
-     * Schreibt Rating und/oder Label in die JPEG-Datei.
+     * Schreibt Rating und/oder Label und/oder Pick in die JPEG-Datei.
      * Alle anderen XMP-Felder (Lightroom-Metadaten etc.) bleiben erhalten.
      *
      * @param  File         $file   Nextcloud File-Objekt
      * @param  int|null     $rating 0–5 (null = nicht ändern)
      * @param  string|null  $label  Red/Yellow/Green/Blue/Purple/'' (null = nicht ändern, '' = entfernen)
+     * @param  string|null  $pick   pick/reject/none (null = nicht ändern, none = entfernen)
+     * @param  string       $lang   'en' (Bridge/digiKam) oder 'de' (Lightroom DE) — beeinflusst nur xmp:Label
      * @throws \RuntimeException bei Fehler
      */
-    public function writeMetadata(File $file, ?int $rating = null, ?string $label = null): void
-    {
-        $this->validateInputs($rating, $label);
+    public function writeMetadata(
+        File $file,
+        ?int $rating = null,
+        ?string $label = null,
+        ?string $pick = null,
+        string $lang = XmpService::LABEL_LANG_EN,
+    ): void {
+        $this->validateInputs($rating, $label, $pick);
 
         $content = $file->getContent();
         if (!$this->isJpeg($content)) {
             throw new \RuntimeException("Not a valid JPEG file: " . $file->getName());
         }
 
-        $updated = $this->applyMetadataToContent($content, $rating, $label);
+        $updated = $this->applyMetadataToContent($content, $rating, $label, $pick, $lang);
         $file->putContent($updated);
 
         $this->logger->info(sprintf(
-            'StarRate: XMP written to %s — rating: %s, label: %s',
+            'StarRate: XMP written to %s — rating: %s, label: %s, pick: %s, lang: %s',
             $file->getName(),
             $rating ?? 'unchanged',
-            $label  ?? 'unchanged'
+            $label  ?? 'unchanged',
+            $pick   ?? 'unchanged',
+            $lang
         ));
     }
 
     /**
      * Liest Rating und Label aus einer JPEG-Datei.
      *
-     * @return array{rating: int, label: string|null}
+     * @return array{rating: int, label: string|null, pick: string}
      */
     public function readMetadata(File $file): array
     {
@@ -79,55 +89,68 @@ class ExifService
             // typically well within 256 KB.  Avoids loading 30 MB+ RAW JPEGs.
             $handle = $file->fopen('rb');
             if ($handle === false) {
-                return ['rating' => 0, 'label' => null];
+                return self::emptyResult();
             }
             $header = fread($handle, self::READ_HEADER_SIZE);
             fclose($handle);
 
             if ($header === false || !$this->isJpeg($header)) {
-                return ['rating' => 0, 'label' => null];
+                return self::emptyResult();
             }
             $xmp = $this->readXmpFromContent($header);
-            if ($xmp['rating'] === 0 && $xmp['label'] === null) {
+            // EXIF-Fallback nur wenn das XMP komplett leer war — sonst überschreiben
+            // wir z.B. einen vorhandenen Pick-Wert mit dem leeren EXIF-Default.
+            if ($xmp['rating'] === 0 && $xmp['label'] === null && $xmp['pick'] === 'none') {
                 return $this->readExifRatingFromContent($header);
             }
             return $xmp;
         } catch (\Exception $e) {
             $this->logger->warning("StarRate: failed to read metadata from {$file->getName()}: " . $e->getMessage());
-            return ['rating' => 0, 'label' => null];
+            return self::emptyResult();
         }
     }
 
     /**
      * Liest Metadaten aus rohem JPEG-Inhalt (für Tests und interne Nutzung).
      *
-     * @return array{rating: int, label: string|null}
+     * @return array{rating: int, label: string|null, pick: string}
      */
     public function readMetadataFromContent(string $content): array
     {
         if (!$this->isJpeg($content)) {
-            return ['rating' => 0, 'label' => null];
+            return self::emptyResult();
         }
         $xmp = $this->readXmpFromContent($content);
-        if ($xmp['rating'] === 0 && $xmp['label'] === null) {
+        if ($xmp['rating'] === 0 && $xmp['label'] === null && $xmp['pick'] === 'none') {
             return $this->readExifRatingFromContent($content);
         }
         return $xmp;
+    }
+
+    /** @return array{rating: int, label: string|null, pick: string} */
+    private static function emptyResult(): array
+    {
+        return ['rating' => 0, 'label' => null, 'pick' => 'none'];
     }
 
     /**
      * Schreibt Metadaten in rohen JPEG-Inhalt und gibt den aktualisierten Inhalt zurück.
      * Alle anderen XMP-Felder bleiben erhalten. Hauptsächlich für Tests.
      */
-    public function writeMetadataToContent(string $content, ?int $rating = null, ?string $label = null): string
-    {
-        $this->validateInputs($rating, $label);
+    public function writeMetadataToContent(
+        string $content,
+        ?int $rating = null,
+        ?string $label = null,
+        ?string $pick = null,
+        string $lang = XmpService::LABEL_LANG_EN,
+    ): string {
+        $this->validateInputs($rating, $label, $pick);
 
         if (!$this->isJpeg($content)) {
             throw new \RuntimeException('Content is not a valid JPEG.');
         }
 
-        return $this->applyMetadataToContent($content, $rating, $label);
+        return $this->applyMetadataToContent($content, $rating, $label, $pick, $lang);
     }
 
     /**
@@ -151,18 +174,20 @@ class ExifService
     // ─── Kernlogik: Metadaten anwenden ───────────────────────────────────────
 
     /**
-     * Wendet Rating und Label auf JPEG-Inhalt an.
+     * Wendet Rating, Label und Pick auf JPEG-Inhalt an.
      * Vorhandene XMP-Felder (Lightroom-Metadaten etc.) bleiben erhalten.
      */
-    private function applyMetadataToContent(string $content, ?int $rating, ?string $label): string
+    private function applyMetadataToContent(string $content, ?int $rating, ?string $label, ?string $pick, string $lang): string
     {
         $xmpBlock = $this->extractXmpBlock($content);
-        $existing = $xmpBlock !== null ? $this->parseXmp($xmpBlock) : ['rating' => 0, 'label' => null];
-        $merged   = $this->mergeXmpData($existing, $rating, $label);
+        $existing = $xmpBlock !== null
+            ? $this->parseXmp($xmpBlock)
+            : ['rating' => 0, 'label' => null, 'pick' => 'none'];
+        $merged   = $this->mergeXmpData($existing, $rating, $label, $pick);
 
         $newXmp = $xmpBlock !== null
-            ? $this->patchXmpString($xmpBlock, $merged['rating'], $merged['label'])
-            : $this->buildXmpPacket($merged['rating'], $merged['label']);
+            ? $this->patchXmpString($xmpBlock, $merged['rating'], $merged['label'], $merged['pick'], $lang)
+            : $this->buildXmpPacket($merged['rating'], $merged['label'], $merged['pick'], $lang);
 
         return $this->embedXmpInJpeg($content, $newXmp);
     }
@@ -175,23 +200,60 @@ class ExifService
      * Schreibt immer in Attribut-Form zurück, konsistent mit dem Prefix der Datei.
      * Bei Multi-Block-XMP wird der Block mit der xmlns:xmp/xap-Deklaration gezielt befüllt.
      */
-    private function patchXmpString(string $existingXmp, int $rating, ?string $label): string
+    private function patchXmpString(string $existingXmp, int $rating, ?string $label, ?string $pick = 'none', string $lang = XmpService::LABEL_LANG_EN): string
     {
         $patched = $existingXmp;
 
-        // Vorhandene Rating- und Label-Felder entfernen (xmp: und xap:, Attribut- und Element-Form)
+        // Vorhandene Rating-, Label- und Pick-Felder entfernen.
+        // photoshop:LabelColor und xmpDM:pick/good werden ebenfalls weggeräumt, sonst bliebe
+        // ein veralteter Wert stehen und LR/Bridge würde beim Re-Import unsere Änderung ignorieren.
+        // Altes flashView:IsPicked/IsRejected (inkl. xmlns:flashView) wird aktiv aufgeräumt
+        // — neues Schema ist xmpDM:pick (Bridge/LRC-Standard).
         $patched = preg_replace('/[ \t]*(?:xmp|xap):Rating\s*=\s*(?:"[^"]*"|\'[^\']*\')/', '', $patched) ?? $patched;
         $patched = preg_replace('/<(?:xmp|xap):Rating>[^<]*<\/(?:xmp|xap):Rating>\s*/',    '', $patched) ?? $patched;
         $patched = preg_replace('/[ \t]*(?:xmp|xap):Label\s*=\s*(?:"[^"]*"|\'[^\']*\')/', '', $patched) ?? $patched;
         $patched = preg_replace('/<(?:xmp|xap):Label>[^<]*<\/(?:xmp|xap):Label>\s*/',      '', $patched) ?? $patched;
+        $patched = preg_replace('/[ \t]*photoshop:LabelColor\s*=\s*(?:"[^"]*"|\'[^\']*\')/', '', $patched) ?? $patched;
+        $patched = preg_replace('/<photoshop:LabelColor>[^<]*<\/photoshop:LabelColor>\s*/',  '', $patched) ?? $patched;
+        $patched = preg_replace('/[ \t]*xmpDM:pick\s*=\s*(?:"[^"]*"|\'[^\']*\')/', '', $patched) ?? $patched;
+        $patched = preg_replace('/<xmpDM:pick>[^<]*<\/xmpDM:pick>\s*/',             '', $patched) ?? $patched;
+        $patched = preg_replace('/[ \t]*xmpDM:good\s*=\s*(?:"[^"]*"|\'[^\']*\')/', '', $patched) ?? $patched;
+        $patched = preg_replace('/<xmpDM:good>[^<]*<\/xmpDM:good>\s*/',             '', $patched) ?? $patched;
+        $patched = preg_replace('/[ \t]*flashView:Is(?:Picked|Rejected)\s*=\s*(?:"[^"]*"|\'[^\']*\')/', '', $patched) ?? $patched;
+        $patched = preg_replace('/<flashView:Is(?:Picked|Rejected)>[^<]*<\/flashView:Is(?:Picked|Rejected)>\s*/', '', $patched) ?? $patched;
+        // Verwaiste flashView-Namespace-Deklaration entfernen (Whitespace-Linie + Attribut)
+        $patched = preg_replace('/[ \t]*xmlns:flashView\s*=\s*(?:"[^"]*"|\'[^\']*\')/', '', $patched) ?? $patched;
 
         // Richtigen Block finden: der mit xmlns:xmp= oder xmlns:xap= Deklaration.
         // Bei Multi-Block-XMP (exiftool, FujiFilm etc.) sitzt xmp: oft nicht in Block 1.
-        [$targetBlock, $needsNsDecl, $prefix] = $this->findXmpBlock($patched);
+        [$targetBlock, $needsNsDecl, $needsPhotoshopNs, $needsXmpDmNs, $prefix] = $this->findXmpBlock($patched);
 
-        $ratingAttr = "\n      {$prefix}:Rating=\"{$rating}\"";
-        $labelAttr  = ($label !== null && $label !== '') ? "\n      {$prefix}:Label=\"{$label}\"" : '';
-        $nsDecl     = $needsNsDecl ? "\n      xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\"" : '';
+        $hasLabel        = ($label !== null && $label !== '');
+        $hasPick         = ($pick !== null && $pick !== '' && $pick !== 'none');
+
+        $ratingAttr      = "\n      {$prefix}:Rating=\"{$rating}\"";
+        // xmp:Label wird ggf. lokalisiert (Bridge-/digiKam-EN vs LR-DE).
+        // photoshop:LabelColor bleibt unabhängig immer lowercase EN.
+        $localizedLabel  = $hasLabel ? XmpService::localizeLabel($label, $lang) : $label;
+        $labelAttr       = $hasLabel ? "\n      {$prefix}:Label=\"{$localizedLabel}\"" : '';
+        $photoshopAttr   = $hasLabel ? "\n      photoshop:LabelColor=\"" . strtolower($label) . "\"" : '';
+
+        // pick → xmpDM:pick="1" + xmpDM:good="true"
+        // reject → xmpDM:pick="-1" + xmpDM:good="false"
+        $pickAttr = '';
+        if ($hasPick) {
+            $pickNum  = $pick === 'pick' ? '1'    : '-1';
+            $goodVal  = $pick === 'pick' ? 'true' : 'false';
+            $pickAttr = "\n      xmpDM:pick=\"{$pickNum}\"\n      xmpDM:good=\"{$goodVal}\"";
+        }
+
+        $nsDecl          = $needsNsDecl ? "\n      xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\"" : '';
+        $photoshopNsDecl = ($hasLabel && $needsPhotoshopNs)
+            ? "\n      xmlns:photoshop=\"http://ns.adobe.com/photoshop/1.0/\""
+            : '';
+        $xmpDmNsDecl     = ($hasPick && $needsXmpDmNs)
+            ? "\n      xmlns:xmpDM=\"http://ns.adobe.com/xmp/1.0/DynamicMedia/\""
+            : '';
 
         // In den gefundenen Block injizieren (limit=-1 damit der Callback alle Blöcke sieht,
         // aber nur den Zielblock modifiziert).
@@ -199,12 +261,15 @@ class ExifService
         $count    = 0;
         $injected = preg_replace_callback(
             '/(<rdf:Description\b[^>]*?)\s*(\/?>)/s',
-            static function (array $m) use ($ratingAttr, $labelAttr, $nsDecl, $targetBlock, &$seen): string {
+            static function (array $m) use ($ratingAttr, $labelAttr, $photoshopAttr, $pickAttr, $nsDecl, $photoshopNsDecl, $xmpDmNsDecl, $targetBlock, &$seen): string {
                 $seen++;
                 if ($seen !== $targetBlock) {
                     return $m[0];
                 }
-                return $m[1] . $nsDecl . $ratingAttr . $labelAttr . "\n    " . $m[2];
+                return $m[1]
+                    . $nsDecl . $photoshopNsDecl . $xmpDmNsDecl
+                    . $ratingAttr . $labelAttr . $photoshopAttr . $pickAttr
+                    . "\n    " . $m[2];
             },
             $patched,
             -1,
@@ -213,7 +278,7 @@ class ExifService
 
         // Fallback: kein rdf:Description gefunden oder Regex-Fehler → frisches XMP
         if ($injected === null || $count === 0) {
-            return $this->xmpService->buildXmpContent($rating, $label);
+            return $this->xmpService->buildXmpContent($rating, $label, $pick, $lang);
         }
 
         return $injected;
@@ -222,15 +287,15 @@ class ExifService
     // ─── XMP lesen ────────────────────────────────────────────────────────────
 
     /**
-     * Extrahiert xmp:Rating und xmp:Label aus dem JPEG-Inhalt.
+     * Extrahiert Rating, Label und Pick aus dem JPEG-Inhalt.
      *
-     * @return array{rating: int, label: string|null}
+     * @return array{rating: int, label: string|null, pick: string}
      */
     private function readXmpFromContent(string $content): array
     {
         $xmpBlock = $this->extractXmpBlock($content);
         if ($xmpBlock === null) {
-            return ['rating' => 0, 'label' => null];
+            return self::emptyResult();
         }
 
         return $this->parseXmp($xmpBlock);
@@ -238,21 +303,21 @@ class ExifService
 
     /**
      * Liest EXIF-Rating als Fallback wenn kein XMP vorhanden (z.B. digiKam-Bilder).
-     * EXIF kennt kein Farb-Label — label bleibt immer null.
+     * EXIF kennt kein Farb-Label und kein Pick-Flag — beide bleiben Default.
      *
-     * @return array{rating: int, label: string|null}
+     * @return array{rating: int, label: string|null, pick: string}
      */
     private function readExifRatingFromContent(string $content): array
     {
         if (!function_exists('exif_read_data')) {
-            return ['rating' => 0, 'label' => null];
+            return self::emptyResult();
         }
 
         // EXIF steht immer in den ersten Segmenten — 64 KB reichen aus.
         // php://memory vermeidet Tempfile auf der Festplatte.
         $tmp = fopen('php://memory', 'r+b');
         if ($tmp === false) {
-            return ['rating' => 0, 'label' => null];
+            return self::emptyResult();
         }
 
         try {
@@ -264,15 +329,15 @@ class ExifService
         }
 
         if (!is_array($exif) || !isset($exif['Rating'])) {
-            return ['rating' => 0, 'label' => null];
+            return self::emptyResult();
         }
 
         $rating = (int) $exif['Rating'];
         if ($rating < 0 || $rating > 5) {
-            return ['rating' => 0, 'label' => null];
+            return self::emptyResult();
         }
 
-        return ['rating' => $rating, 'label' => null];
+        return ['rating' => $rating, 'label' => null, 'pick' => 'none'];
     }
 
     /**
@@ -325,14 +390,16 @@ class ExifService
 
     /**
      * Merged vorhandene Daten mit neuen Werten (null = bestehenden Wert beibehalten).
+     * Für pick: 'none' und '' gelten als "entfernen", null als "unverändert".
      *
-     * @return array{rating: int, label: string|null}
+     * @return array{rating: int, label: string|null, pick: string}
      */
-    private function mergeXmpData(array $existing, ?int $rating, ?string $label): array
+    private function mergeXmpData(array $existing, ?int $rating, ?string $label, ?string $pick): array
     {
         return [
             'rating' => $rating !== null ? $rating : $existing['rating'],
-            'label'  => $label  !== null ? ($label === '' ? null : $label) : $existing['label'],
+            'label'  => $label  !== null ? ($label === '' ? null : $label) : ($existing['label'] ?? null),
+            'pick'   => $pick   !== null ? ($pick === '' ? 'none' : $pick) : ($existing['pick'] ?? 'none'),
         ];
     }
 
@@ -340,9 +407,9 @@ class ExifService
      * Baut ein vollständiges XMP-Paket als String.
      * Delegiert an XmpService::buildXmpContent().
      */
-    private function buildXmpPacket(int $rating, ?string $label): string
+    private function buildXmpPacket(int $rating, ?string $label, ?string $pick = null, string $lang = XmpService::LABEL_LANG_EN): string
     {
-        return $this->xmpService->buildXmpContent($rating, $label);
+        return $this->xmpService->buildXmpContent($rating, $label, $pick, $lang);
     }
 
     /**
@@ -415,12 +482,14 @@ class ExifService
     /**
      * Findet den rdf:Description-Block mit xmp:- oder xap:-Namespace-Deklaration.
      *
-     * Gibt [blockIndex (1-basiert), needsNsDecl, prefix] zurück:
-     *  - blockIndex:  welcher Block (1 = erster)
-     *  - needsNsDecl: true wenn kein Block xmlns:xmp deklariert → in Block 1 ergänzen
-     *  - prefix:      'xmp' oder 'xap' (konsistent mit dem was die Datei benutzt)
+     * Gibt [blockIndex (1-basiert), needsNsDecl, needsPhotoshopNs, needsXmpDmNs, prefix] zurück:
+     *  - blockIndex:        welcher Block (1 = erster)
+     *  - needsNsDecl:       true wenn kein Block xmlns:xmp deklariert → in Block 1 ergänzen
+     *  - needsPhotoshopNs:  true wenn der Zielblock xmlns:photoshop nicht deklariert
+     *  - needsXmpDmNs:      true wenn der Zielblock xmlns:xmpDM nicht deklariert
+     *  - prefix:            'xmp' oder 'xap' (konsistent mit dem was die Datei benutzt)
      *
-     * @return array{int, bool, string}
+     * @return array{int, bool, bool, bool, string}
      */
     private function findXmpBlock(string $xmp): array
     {
@@ -430,15 +499,19 @@ class ExifService
 
         foreach ($matches[1] as $i => $openingTag) {
             if (str_contains($openingTag, 'xmlns:xmp=')) {
-                return [$i + 1, false, 'xmp'];
+                $needsPhotoshop = !str_contains($openingTag, 'xmlns:photoshop=');
+                $needsXmpDm     = !str_contains($openingTag, 'xmlns:xmpDM=');
+                return [$i + 1, false, $needsPhotoshop, $needsXmpDm, 'xmp'];
             }
             if (str_contains($openingTag, 'xmlns:xap=')) {
-                return [$i + 1, false, 'xap'];
+                $needsPhotoshop = !str_contains($openingTag, 'xmlns:photoshop=');
+                $needsXmpDm     = !str_contains($openingTag, 'xmlns:xmpDM=');
+                return [$i + 1, false, $needsPhotoshop, $needsXmpDm, 'xap'];
             }
         }
 
-        // Kein Block mit xmp/xap-Namespace → Block 1, xmlns:xmp ergänzen
-        return [1, true, 'xmp'];
+        // Kein Block mit xmp/xap-Namespace → Block 1, alle Namespaces ergänzen
+        return [1, true, true, true, 'xmp'];
     }
 
     private function isJpeg(string $content): bool
@@ -448,7 +521,7 @@ class ExifService
             && $content[1] === "\xD8";
     }
 
-    private function validateInputs(?int $rating, ?string $label): void
+    private function validateInputs(?int $rating, ?string $label, ?string $pick = null): void
     {
         if ($rating !== null && ($rating < 0 || $rating > 5)) {
             throw new \InvalidArgumentException("Rating must be between 0 and 5, got: {$rating}");
@@ -457,6 +530,12 @@ class ExifService
         if ($label !== null && $label !== '' && !isset(self::LABEL_MAP[$label])) {
             throw new \InvalidArgumentException(
                 "Invalid label: {$label}. Allowed: " . implode(', ', array_keys(self::LABEL_MAP))
+            );
+        }
+
+        if ($pick !== null && $pick !== '' && !in_array($pick, XmpService::VALID_PICKS, true)) {
+            throw new \InvalidArgumentException(
+                "Invalid pick: {$pick}. Allowed: " . implode(', ', XmpService::VALID_PICKS)
             );
         }
     }

--- a/lib/Service/XmpService.php
+++ b/lib/Service/XmpService.php
@@ -32,6 +32,23 @@ class XmpService
         'Lila' => 'Purple',
     ];
 
+    // Kanonisches EN → deutsches LR-Standard-Label-Set
+    // Beim Schreiben im Modus "Lightroom (deutsche Lokalisierung)" verwendet, damit
+    // DE-LRC den xmp:Label-String matchen kann (sonst zeigt LR "Custom" / weiße Fahne).
+    // photoshop:LabelColor bleibt unabhängig immer lowercase EN — das treibt den
+    // Farbstreifen in LR und ist universell.
+    private const LABEL_MAP_DE = [
+        'Red'    => 'Rot',
+        'Yellow' => 'Gelb',
+        'Green'  => 'Grün',
+        'Blue'   => 'Blau',
+        'Purple' => 'Lila',
+    ];
+
+    public const LABEL_LANG_EN = 'en';
+    public const LABEL_LANG_DE = 'de';
+    public const VALID_LABEL_LANGS = [self::LABEL_LANG_EN, self::LABEL_LANG_DE];
+
     // digiKam:ColorLabel → kanonisch englisch (numerische Werte 0–10)
     // Werte ohne StarRate-Äquivalent (2=Orange, 7=Grey, 8=Black, 9=White, 10=Darkred) → null
     private const DIGIKAM_COLOR_MAP = [
@@ -42,13 +59,22 @@ class XmpService
         6 => 'Purple',
     ];
 
+    // Pick-Werte → xmpDM-Attribut-Paare (LRC/Bridge-kompatibel)
+    // xmpDM:pick: 1=Pick, -1=Reject, 0=none (none entspricht: Attribute komplett weglassen)
+    // xmpDM:good: redundantes Boolean (true=Pick, false=Reject), wird parallel geschrieben
+    public const VALID_PICKS = ['pick', 'reject', 'none'];
+    private const PICK_MAP = [
+        'pick'   => ['pick' => '1',  'good' => 'true'],
+        'reject' => ['pick' => '-1', 'good' => 'false'],
+    ];
+
     private const XMP_TEMPLATE = <<<'XMP'
 <?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
 <x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='StarRate 1.0'>
   <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
     <rdf:Description rdf:about=''
-      xmlns:xmp='http://ns.adobe.com/xap/1.0/'
-      %RATING_ATTR%%LABEL_ATTR%>
+      xmlns:xmp='http://ns.adobe.com/xap/1.0/'%PHOTOSHOP_NS%%XMPDM_NS%
+      %RATING_ATTR%%LABEL_ATTR%%PICK_ATTR%>
     </rdf:Description>
   </rdf:RDF>
 </x:xmpmeta>
@@ -59,15 +85,47 @@ XMP;
 
     /**
      * Baut den XMP-Sidecar-Inhalt als String.
+     *
+     * Schreibt sowohl xmp:Label (sprachneutral kanonisch EN) als auch
+     * photoshop:LabelColor (lowercase EN) — analog zu Lightroom Classic.
+     * photoshop:LabelColor ist beim Re-Import durch LR persistenter, da LR
+     * dieses Feld mit Priorität 1 liest.
+     *
+     * Pick/Reject als xmpDM:pick (1/-1) + xmpDM:good (true/false) — Bridge-/LRC-kompatibel.
+     * Bei pick='none' oder pick=null werden die Attribute komplett weggelassen.
+     *
+     * @param string $lang 'en' = Bridge/digiKam-kompatibel (Red/Yellow/…),
+     *                     'de' = Lightroom DE-Lokalisierung (Rot/Gelb/…).
+     *                     Beeinflusst nur xmp:Label, nicht photoshop:LabelColor.
      */
-    public function buildXmpContent(int $rating, ?string $label): string
+    public function buildXmpContent(int $rating, ?string $label, ?string $pick = null, string $lang = self::LABEL_LANG_EN): string
     {
         $ratingAttr = "xmp:Rating=\"{$rating}\"";
-        $labelAttr  = $label ? "\n      xmp:Label=\"{$label}\"" : '';
+
+        if ($label) {
+            $labelLower    = strtolower($label);
+            $localized     = self::localizeLabel($label, $lang);
+            $labelAttr     = "\n      xmp:Label=\"{$localized}\""
+                           . "\n      photoshop:LabelColor=\"{$labelLower}\"";
+            $photoshopNs   = "\n      xmlns:photoshop='http://ns.adobe.com/photoshop/1.0/'";
+        } else {
+            $labelAttr   = '';
+            $photoshopNs = '';
+        }
+
+        if (isset(self::PICK_MAP[$pick])) {
+            $pickValues = self::PICK_MAP[$pick];
+            $pickAttr   = "\n      xmpDM:pick=\"{$pickValues['pick']}\""
+                        . "\n      xmpDM:good=\"{$pickValues['good']}\"";
+            $xmpDmNs    = "\n      xmlns:xmpDM='http://ns.adobe.com/xmp/1.0/DynamicMedia/'";
+        } else {
+            $pickAttr = '';
+            $xmpDmNs  = '';
+        }
 
         $xmp = str_replace(
-            ['%RATING_ATTR%', '%LABEL_ATTR%'],
-            [$ratingAttr, $labelAttr],
+            ['%RATING_ATTR%', '%LABEL_ATTR%', '%PICK_ATTR%', '%PHOTOSHOP_NS%', '%XMPDM_NS%'],
+            [$ratingAttr, $labelAttr, $pickAttr, $photoshopNs, $xmpDmNs],
             self::XMP_TEMPLATE
         );
 
@@ -75,7 +133,7 @@ XMP;
     }
 
     /**
-     * Parst einen XMP-String und gibt Rating + Label zurück.
+     * Parst einen XMP-String und gibt Rating + Label + Pick zurück.
      *
      * Rating-Auflösung:
      *  xmp:Rating / xap:Rating (xap: ist der alte exiftool/IDimager Alias, gleiche Namespace-URI)
@@ -85,12 +143,17 @@ XMP;
      *  2. xmp:Label             — Standard, sprachabhängig (Red/Rot/Rouge/…)
      *  3. digiKam:ColorLabel    — numerisch (1=Red, 3=Yellow, 4=Green, 5=Blue, 6=Purple)
      *
-     * @return array{rating: int, label: string|null}
+     * Pick-Auflösung (Priorität hoch → niedrig):
+     *  1. xmpDM:pick   — 1=Pick, -1=Reject, 0=none (Bridge/LRC-Standard)
+     *  2. flashView:IsPicked / flashView:IsRejected — alter FlashView-Namespace (rückwärtskompatibel)
+     *
+     * @return array{rating: int, label: string|null, pick: string}
      */
     public function parseXmpContent(string $xmp): array
     {
         $rating = 0;
         $label  = null;
+        $pick   = 'none';
 
         // xmp:Rating / xap:Rating als Attribut oder Element
         if (preg_match('/(?:xmp|xap):Rating\s*=\s*[\'"](\d+)[\'"]/', $xmp, $m)) {
@@ -122,7 +185,40 @@ XMP;
             $label = self::DIGIKAM_COLOR_MAP[(int) $m[1]] ?? null;
         }
 
-        return ['rating' => $rating, 'label' => $label];
+        // xmpDM:pick (Prio 1) — 1=Pick, -1=Reject, 0/sonst=none
+        if (preg_match('/xmpDM:pick\s*=\s*[\'"](-?\d+)[\'"]/', $xmp, $m)
+            || preg_match('/<xmpDM:pick>(-?\d+)<\/xmpDM:pick>/', $xmp, $m)) {
+            $pickVal = (int) $m[1];
+            if ($pickVal === 1) {
+                $pick = 'pick';
+            } elseif ($pickVal === -1) {
+                $pick = 'reject';
+            }
+        }
+
+        // flashView:IsPicked / IsRejected (Prio 2, nur wenn xmpDM:pick nicht aufgelöst)
+        // Rückwärtskompatibel mit altem FlashView-Schema (vor xmpDM-Migration)
+        if ($pick === 'none') {
+            if (preg_match('/flashView:IsPicked\s*=\s*[\'"](True|true|1)[\'"]/', $xmp)) {
+                $pick = 'pick';
+            } elseif (preg_match('/flashView:IsRejected\s*=\s*[\'"](True|true|1)[\'"]/', $xmp)) {
+                $pick = 'reject';
+            }
+        }
+
+        return ['rating' => $rating, 'label' => $label, 'pick' => $pick];
+    }
+
+    /**
+     * Übersetzt einen kanonisch englischen Label-Namen in die Ziel-Sprache.
+     * Unbekannte Sprachen oder Labels → unverändert (EN).
+     */
+    public static function localizeLabel(string $canonicalEn, string $lang): string
+    {
+        if ($lang === self::LABEL_LANG_DE && isset(self::LABEL_MAP_DE[$canonicalEn])) {
+            return self::LABEL_MAP_DE[$canonicalEn];
+        }
+        return $canonicalEn;
     }
 
     /**

--- a/lib/Settings/UserSettings.php
+++ b/lib/Settings/UserSettings.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OCA\StarRate\Settings;
 
+use OCA\StarRate\Service\XmpService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
@@ -63,6 +64,11 @@ class UserSettings implements ISettings
             'grid_columns'             => $this->get($userId, 'grid_columns', 'auto'),
             'enable_pick_ui'           => $this->getBool($userId, 'enable_pick_ui', false),
             'write_xmp'                => $this->getBool($userId, 'write_xmp', true),
+            // XMP-Label-Sprache: 'de' = Lightroom DE-Lokalisierung (Rot/Gelb/…),
+            // 'en' = Bridge/digiKam/englische Tools (Red/Yellow/…). Default leitet
+            // sich aus der NC-UI-Sprache ab (de_* → de, sonst en) damit DE-User
+            // sofort funktionierende LR-DE-Imports bekommen, ohne Setting anzufassen.
+            'xmp_label_language'       => $this->get($userId, 'xmp_label_language', $this->defaultLabelLanguage($userId)),
             'comments_enabled'         => $this->getBool($userId, 'comments_enabled', false),
             // Recursive-View Defaults — werden beim Folder-Open als initiale
             // Werte verwendet; URL-Params können sie pro View überschreiben.
@@ -93,6 +99,7 @@ class UserSettings implements ISettings
             'show_color_overlay', 'grid_columns', 'enable_pick_ui', 'write_xmp', 'comments_enabled',
             'recursion_enabled', 'recursive_default', 'recursive_default_depth',
             'slideshow_interval',
+            'xmp_label_language',
         ];
 
         foreach ($data as $key => $value) {
@@ -138,10 +145,24 @@ class UserSettings implements ISettings
             'grid_columns' => $this->assertIn($key, $value, ['auto', '2', '3', '4', '5', '6', '8']),
             'recursive_default_depth' => $this->assertIntRange($key, $value, 0, 4),
             'slideshow_interval' => $this->assertIn($key, (int) $value, self::SLIDESHOW_INTERVALS),
+            'xmp_label_language' => $this->assertIn($key, $value, XmpService::VALID_LABEL_LANGS),
             'show_filename', 'show_rating_overlay', 'show_color_overlay',
             'enable_pick_ui', 'write_xmp', 'comments_enabled',
             'recursion_enabled', 'recursive_default' => null,
         };
+    }
+
+    /**
+     * Leitet die Default-Label-Sprache aus der NC-UI-Sprache des Users ab.
+     * de_* → 'de' (LR DE-Lokalisierung), sonst → 'en' (Bridge/digiKam-Standard).
+     */
+    private function defaultLabelLanguage(string $userId): string
+    {
+        if ($userId === '') {
+            return XmpService::LABEL_LANG_EN;
+        }
+        $lang = $this->config->getUserValue($userId, 'core', 'lang', '');
+        return str_starts_with($lang, 'de') ? XmpService::LABEL_LANG_DE : XmpService::LABEL_LANG_EN;
     }
 
     private function assertIntRange(string $key, mixed $value, int $min, int $max): void

--- a/src/views/SettingsPanel.vue
+++ b/src/views/SettingsPanel.vue
@@ -15,6 +15,19 @@
           {{ t('starrate', 'XMP in JPEG schreiben') }}
         </label>
       </div>
+
+      <div v-if="form.write_xmp" class="sr-settings__row">
+        <label class="sr-settings__label">{{ t('starrate', 'Farb-Bewertungen kompatibel mit') }}</label>
+        <div class="sr-settings__control">
+          <select v-model="form.xmp_label_language" class="sr-settings__select" @change="autosave">
+            <option value="de">{{ t('starrate', 'Lightroom (deutsche Lokalisierung)') }}</option>
+            <option value="en">{{ t('starrate', 'Bridge / digiKam / englische Tools') }}</option>
+          </select>
+        </div>
+      </div>
+      <p v-if="form.write_xmp" class="sr-settings__hint">
+        {{ t('starrate', 'Steuert nur den Label-Text (xmp:Label). Der Farbstreifen (photoshop:LabelColor) bleibt sprachneutral und funktioniert in beiden Modi.') }}
+      </p>
       <div class="sr-settings__row">
         <label class="sr-settings__label sr-settings__label--check">
           <input type="checkbox" v-model="form.comments_enabled" @change="autosave" />
@@ -169,6 +182,7 @@ const DEFAULTS = {
   grid_columns:             'auto',
   enable_pick_ui:            false,
   write_xmp:                 true,
+  xmp_label_language:        'en',  // Server-seitig basierend auf User-Locale gesetzt
   comments_enabled:          false,
   recursion_enabled:         false,
   recursive_default:         false,

--- a/tests/Unit/Controller/RatingControllerTest.php
+++ b/tests/Unit/Controller/RatingControllerTest.php
@@ -61,7 +61,8 @@ class RatingControllerTest extends TestCase
 
         // Default: write_xmp aktiv, comments_enabled aktiv
         $this->userSettings->method('getSettings')->willReturn([
-            'write_xmp'        => true,
+            'write_xmp'          => true,
+            'xmp_label_language' => 'en',
             'comments_enabled' => true,
         ]);
 
@@ -429,7 +430,8 @@ class RatingControllerTest extends TestCase
     {
         $this->userSettings = $this->createMock(UserSettings::class);
         $this->userSettings->method('getSettings')->willReturn([
-            'write_xmp'        => true,
+            'write_xmp'          => true,
+            'xmp_label_language' => 'en',
             'comments_enabled' => false,
         ]);
 
@@ -471,7 +473,8 @@ class RatingControllerTest extends TestCase
     {
         $this->userSettings = $this->createMock(UserSettings::class);
         $this->userSettings->method('getSettings')->willReturn([
-            'write_xmp'        => true,
+            'write_xmp'          => true,
+            'xmp_label_language' => 'en',
             'comments_enabled' => false,
         ]);
 
@@ -501,7 +504,8 @@ class RatingControllerTest extends TestCase
     {
         $this->userSettings = $this->createMock(UserSettings::class);
         $this->userSettings->method('getSettings')->willReturn([
-            'write_xmp'        => true,
+            'write_xmp'          => true,
+            'xmp_label_language' => 'en',
             'comments_enabled' => false,
         ]);
 

--- a/tests/Unit/Service/ExifServiceTest.php
+++ b/tests/Unit/Service/ExifServiceTest.php
@@ -312,6 +312,242 @@ class ExifServiceTest extends TestCase
     }
 
     /**
+     * Baut JPEG mit XMP, das bereits photoshop:LabelColor enthält (wie LR-Export).
+     */
+    private function makeJpegWithPhotoshopLabelColor(string $psValue, string $xmpLabel): string
+    {
+        $xmp = "<?xpacket begin='\xef\xbb\xbf' id='W5M0MpCehiHzreSzNTczkc9d'?>\n"
+            . "<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='Adobe XMP Core 6.0.0'>\n"
+            . "  <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>\n"
+            . "    <rdf:Description rdf:about=''\n"
+            . "      xmlns:xmp='http://ns.adobe.com/xap/1.0/'\n"
+            . "      xmlns:photoshop='http://ns.adobe.com/photoshop/1.0/'\n"
+            . "      xmp:Rating='2'\n"
+            . "      xmp:Label='{$xmpLabel}'\n"
+            . "      photoshop:LabelColor='{$psValue}'>\n"
+            . "    </rdf:Description>\n"
+            . "  </rdf:RDF>\n"
+            . "</x:xmpmeta>\n"
+            . "<?xpacket end='w'?>";
+
+        $magic   = "http://ns.adobe.com/xap/1.0/\x00";
+        $payload = $magic . $xmp;
+        $segLen  = strlen($payload) + 2;
+        $app1Seg = "\xFF\xE1" . chr(($segLen >> 8) & 0xFF) . chr($segLen & 0xFF) . $payload;
+
+        $base = $this->makeMinimalJpeg();
+        return substr($base, 0, 2) . $app1Seg . substr($base, 2);
+    }
+
+    /**
+     * Regression: vorher blieb stale `photoshop:LabelColor="green"` stehen, wenn StarRate
+     * das Label auf Red änderte. LR liest photoshop:LabelColor mit Prio 1 → Round-Trip
+     * zeigt das alte (falsche) Label. Jetzt werden beide Felder synchron aktualisiert.
+     */
+    public function testStalePhotoshopLabelColorIsReplacedOnLabelChange(): void
+    {
+        // Vorher: xmp:Label="Green" + photoshop:LabelColor="green"
+        $jpeg = $this->makeJpegWithPhotoshopLabelColor('green', 'Green');
+
+        // Schreibe Red
+        $written = $this->service->writeMetadataToContent($jpeg, 5, 'Red');
+
+        // photoshop:LabelColor muss auf "red" aktualisiert sein, nicht "green"
+        $this->assertStringContainsString('photoshop:LabelColor="red"', $written);
+        $this->assertStringNotContainsString('photoshop:LabelColor="green"', $written);
+        $this->assertStringContainsString('xmp:Label="Red"', $written);
+
+        // Round-Trip: parser nimmt photoshop:LabelColor mit Prio 1 → muss Red liefern
+        $result = $this->service->readMetadataFromContent($written);
+        $this->assertSame(5,     $result['rating']);
+        $this->assertSame('Red', $result['label']);
+    }
+
+    public function testPhotoshopLabelColorIsRemovedWhenLabelCleared(): void
+    {
+        $jpeg    = $this->makeJpegWithPhotoshopLabelColor('blue', 'Blue');
+        $written = $this->service->writeMetadataToContent($jpeg, 3, '');
+
+        // Label entfernt → photoshop:LabelColor darf nicht mehr drin sein
+        $this->assertStringNotContainsString('photoshop:LabelColor', $written);
+
+        $result = $this->service->readMetadataFromContent($written);
+        $this->assertSame(3,    $result['rating']);
+        $this->assertNull($result['label']);
+    }
+
+    public function testPhotoshopLabelColorIsAddedToLightroomXmpWithoutNamespace(): void
+    {
+        // Bestehendes XMP hat kein xmlns:photoshop → Inject muss NS-Decl ergänzen
+        $jpeg    = $this->makeJpegWithLightroomXmp();
+        $written = $this->service->writeMetadataToContent($jpeg, 4, 'Yellow');
+
+        $this->assertStringContainsString('xmlns:photoshop=', $written);
+        $this->assertStringContainsString('photoshop:LabelColor="yellow"', $written);
+    }
+
+    // ─── Tests: Label-Sprache (xmp:Label EN vs. DE für LR-Lokalisierung) ─────
+
+    public function testWriteWithLangDeTranslatesXmpLabelInJpeg(): void
+    {
+        $jpeg    = $this->makeMinimalJpeg();
+        $written = $this->service->writeMetadataToContent($jpeg, 5, 'Red', null, 'de');
+
+        // xmp:Label DE, photoshop:LabelColor weiterhin lowercase EN
+        $this->assertStringContainsString('xmp:Label="Rot"',            $written);
+        $this->assertStringContainsString('photoshop:LabelColor="red"', $written);
+        $this->assertStringNotContainsString('xmp:Label="Red"',         $written);
+
+        // Round-Trip: photoshop:LabelColor hat höhere Prio → liefert kanonisch EN
+        $result = $this->service->readMetadataFromContent($written);
+        $this->assertSame(5,     $result['rating']);
+        $this->assertSame('Red', $result['label']);
+    }
+
+    public function testPatchWithLangDeReplacesEnglishLabelInExistingXmp(): void
+    {
+        // Bestehende Datei mit EN xmp:Label. Beim Re-Schreiben mit lang='de' muss
+        // xmp:Label durch DE ersetzt werden, photoshop:LabelColor weiter EN bleiben.
+        $jpeg    = $this->makeJpegWithLightroomXmp(); // hat xmp:Label='Red'
+        $written = $this->service->writeMetadataToContent($jpeg, null, 'Green', null, 'de');
+
+        $this->assertStringContainsString('xmp:Label="Grün"',             $written);
+        $this->assertStringNotContainsString('xmp:Label="Green"',         $written);
+        $this->assertStringNotContainsString('xmp:Label="Red"',           $written);
+        $this->assertStringContainsString('photoshop:LabelColor="green"', $written);
+    }
+
+    // ─── Tests: Pick/Reject (xmpDM) ───────────────────────────────────────────
+
+    public function testWriteAndReadPick(): void
+    {
+        $jpeg    = $this->makeMinimalJpeg();
+        $written = $this->service->writeMetadataToContent($jpeg, null, null, 'pick');
+
+        $this->assertStringContainsString('xmpDM:pick="1"',    $written);
+        $this->assertStringContainsString('xmpDM:good="true"', $written);
+        $this->assertStringContainsString('xmlns:xmpDM=',      $written);
+
+        $result = $this->service->readMetadataFromContent($written);
+        $this->assertSame('pick', $result['pick']);
+    }
+
+    public function testWriteAndReadReject(): void
+    {
+        $jpeg    = $this->makeMinimalJpeg();
+        $written = $this->service->writeMetadataToContent($jpeg, null, null, 'reject');
+
+        $this->assertStringContainsString('xmpDM:pick="-1"',    $written);
+        $this->assertStringContainsString('xmpDM:good="false"', $written);
+
+        $result = $this->service->readMetadataFromContent($written);
+        $this->assertSame('reject', $result['pick']);
+    }
+
+    public function testClearPickRemovesXmpDmAttrs(): void
+    {
+        $jpeg    = $this->makeMinimalJpeg();
+        $picked  = $this->service->writeMetadataToContent($jpeg, 4, 'Red', 'pick');
+        $cleared = $this->service->writeMetadataToContent($picked, null, null, 'none');
+
+        $this->assertStringNotContainsString('xmpDM:pick', $cleared);
+        $this->assertStringNotContainsString('xmpDM:good', $cleared);
+
+        // Rating + Label bleiben erhalten
+        $result = $this->service->readMetadataFromContent($cleared);
+        $this->assertSame(4,      $result['rating']);
+        $this->assertSame('Red',  $result['label']);
+        $this->assertSame('none', $result['pick']);
+    }
+
+    public function testInvalidPickThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->service->writeMetadataToContent($this->makeMinimalJpeg(), null, null, 'maybe');
+    }
+
+    /**
+     * Baut JPEG mit altem FlashView-Schema (vor xmpDM-Migration).
+     */
+    private function makeJpegWithFlashViewPick(string $picked, string $rejected): string
+    {
+        $xmp = "<?xpacket begin='\xef\xbb\xbf' id='W5M0MpCehiHzreSzNTczkc9d'?>\n"
+            . "<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='FlashView 0.9'>\n"
+            . "  <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>\n"
+            . "    <rdf:Description rdf:about=''\n"
+            . "      xmlns:xmp='http://ns.adobe.com/xap/1.0/'\n"
+            . "      xmlns:flashView='http://flashview.net/xmp/1.0/'\n"
+            . "      xmp:Rating='2'\n"
+            . "      flashView:IsPicked='{$picked}'\n"
+            . "      flashView:IsRejected='{$rejected}'>\n"
+            . "    </rdf:Description>\n"
+            . "  </rdf:RDF>\n"
+            . "</x:xmpmeta>\n"
+            . "<?xpacket end='w'?>";
+
+        $magic   = "http://ns.adobe.com/xap/1.0/\x00";
+        $payload = $magic . $xmp;
+        $segLen  = strlen($payload) + 2;
+        $app1Seg = "\xFF\xE1" . chr(($segLen >> 8) & 0xFF) . chr($segLen & 0xFF) . $payload;
+
+        $base = $this->makeMinimalJpeg();
+        return substr($base, 0, 2) . $app1Seg . substr($base, 2);
+    }
+
+    public function testFlashViewIsPickedReadsAsPickRoundTrip(): void
+    {
+        // Lesen erkennt altes Schema
+        $jpeg   = $this->makeJpegWithFlashViewPick('True', 'False');
+        $result = $this->service->readMetadataFromContent($jpeg);
+        $this->assertSame('pick', $result['pick']);
+    }
+
+    public function testWriteCleansUpFlashViewArtifacts(): void
+    {
+        // Datei mit altem FlashView-Schema → Schreiben muss flashView-Attribute UND
+        // den verwaisten xmlns:flashView komplett entfernen.
+        $jpeg    = $this->makeJpegWithFlashViewPick('True', 'False');
+        $written = $this->service->writeMetadataToContent($jpeg, null, null, 'reject');
+
+        // Alte Felder weg
+        $this->assertStringNotContainsString('flashView:IsPicked',   $written);
+        $this->assertStringNotContainsString('flashView:IsRejected', $written);
+        $this->assertStringNotContainsString('xmlns:flashView',      $written);
+
+        // Neues xmpDM-Schema vorhanden, korrekt für reject
+        $this->assertStringContainsString('xmpDM:pick="-1"',    $written);
+        $this->assertStringContainsString('xmpDM:good="false"', $written);
+
+        $result = $this->service->readMetadataFromContent($written);
+        $this->assertSame('reject', $result['pick']);
+    }
+
+    public function testStaleXmpDmPickIsReplacedOnPickChange(): void
+    {
+        $jpeg    = $this->makeMinimalJpeg();
+        $picked  = $this->service->writeMetadataToContent($jpeg, null, null, 'pick');
+        $changed = $this->service->writeMetadataToContent($picked, null, null, 'reject');
+
+        // Nicht beide Werte parallel — nur reject darf übrig sein
+        $this->assertStringContainsString('xmpDM:pick="-1"',    $changed);
+        $this->assertStringNotContainsString('xmpDM:pick="1"',  $changed);
+        $this->assertStringContainsString('xmpDM:good="false"', $changed);
+        $this->assertStringNotContainsString('xmpDM:good="true"', $changed);
+    }
+
+    public function testPickIndependentOfRatingAndLabel(): void
+    {
+        // Setze rating + label + pick zusammen, prüfe alles bleibt erhalten
+        $jpeg    = $this->makeMinimalJpeg();
+        $written = $this->service->writeMetadataToContent($jpeg, 5, 'Blue', 'pick');
+        $result  = $this->service->readMetadataFromContent($written);
+
+        $this->assertSame(5,      $result['rating']);
+        $this->assertSame('Blue', $result['label']);
+        $this->assertSame('pick', $result['pick']);
+    }
+
+    /**
      * Regression: selbst-schließendes rdf:Description (z.B. digiKam-XMP) erzeugte
      * nach dem Schreiben ein unkorrekt geschlossenes Tag ("no closing tag for
      * rdf:Description" in exiftool). Die Ursache war, dass [^>]* das / von />

--- a/tests/Unit/Service/XmpServiceTest.php
+++ b/tests/Unit/Service/XmpServiceTest.php
@@ -35,11 +35,34 @@ class XmpServiceTest extends TestCase
         $this->assertStringContainsString('xmp:Label="Green"', $xmp);
     }
 
+    public function testBuildXmpContentContainsPhotoshopLabelColorLowercase(): void
+    {
+        // photoshop:LabelColor wird parallel zu xmp:Label geschrieben (LR-Kompatibilität)
+        $xmp = $this->service->buildXmpContent(3, 'Green');
+
+        $this->assertStringContainsString('photoshop:LabelColor="green"', $xmp);
+        $this->assertStringContainsString("xmlns:photoshop='http://ns.adobe.com/photoshop/1.0/'", $xmp);
+    }
+
+    /** @dataProvider allColorsProvider */
+    public function testBuildXmpContentPhotoshopLabelColorLowercaseForAllColors(string $color): void
+    {
+        $xmp = $this->service->buildXmpContent(1, $color);
+
+        $this->assertStringContainsString(
+            'photoshop:LabelColor="' . strtolower($color) . '"',
+            $xmp
+        );
+    }
+
     public function testBuildXmpContentWithoutLabelHasNoLabelAttribute(): void
     {
         $xmp = $this->service->buildXmpContent(2, null);
 
         $this->assertStringNotContainsString('xmp:Label', $xmp);
+        $this->assertStringNotContainsString('photoshop:LabelColor', $xmp);
+        // Ohne Label brauchen wir auch keinen photoshop-Namespace
+        $this->assertStringNotContainsString('xmlns:photoshop', $xmp);
     }
 
     public function testBuildXmpContentZeroRating(): void
@@ -253,26 +276,163 @@ XMP;
         $this->assertSame('Green', $result['label']);
     }
 
+    // ─── Tests: Pick/Reject (xmpDM) ───────────────────────────────────────────
+
+    public function testBuildXmpContentWithPick(): void
+    {
+        $xmp = $this->service->buildXmpContent(0, null, 'pick');
+
+        $this->assertStringContainsString('xmpDM:pick="1"',    $xmp);
+        $this->assertStringContainsString('xmpDM:good="true"', $xmp);
+        $this->assertStringContainsString("xmlns:xmpDM='http://ns.adobe.com/xmp/1.0/DynamicMedia/'", $xmp);
+    }
+
+    public function testBuildXmpContentWithReject(): void
+    {
+        $xmp = $this->service->buildXmpContent(0, null, 'reject');
+
+        $this->assertStringContainsString('xmpDM:pick="-1"',    $xmp);
+        $this->assertStringContainsString('xmpDM:good="false"', $xmp);
+    }
+
+    public function testBuildXmpContentWithNonePickHasNoXmpDmAttrs(): void
+    {
+        $xmp = $this->service->buildXmpContent(3, 'Red', 'none');
+
+        $this->assertStringNotContainsString('xmpDM:pick',  $xmp);
+        $this->assertStringNotContainsString('xmpDM:good',  $xmp);
+        // Kein Pick → auch kein xmpDM-Namespace nötig
+        $this->assertStringNotContainsString('xmlns:xmpDM', $xmp);
+    }
+
+    public function testBuildXmpContentWithoutPickArgHasNoXmpDmAttrs(): void
+    {
+        $xmp = $this->service->buildXmpContent(3, 'Red');
+
+        $this->assertStringNotContainsString('xmpDM:',      $xmp);
+        $this->assertStringNotContainsString('xmlns:xmpDM', $xmp);
+    }
+
+    // ─── Tests: Label-Sprache (xmp:Label EN vs. DE für LR-Lokalisierung) ─────
+
+    public function testBuildXmpContentDefaultLangIsEn(): void
+    {
+        // Default 'en' → xmp:Label="Red" (kanonisch, Bridge/digiKam/EN-LR)
+        $xmp = $this->service->buildXmpContent(0, 'Red');
+        $this->assertStringContainsString('xmp:Label="Red"', $xmp);
+    }
+
+    /** @dataProvider deLabelProvider */
+    public function testBuildXmpContentLangDeTranslatesXmpLabel(string $en, string $de): void
+    {
+        $xmp = $this->service->buildXmpContent(0, $en, null, 'de');
+
+        // xmp:Label in DE-Lokalisierung
+        $this->assertStringContainsString("xmp:Label=\"{$de}\"", $xmp);
+        // photoshop:LabelColor BLEIBT lowercase EN — sprachneutral, treibt LR-Farbstreifen
+        $this->assertStringContainsString('photoshop:LabelColor="' . strtolower($en) . '"', $xmp);
+    }
+
+    public static function deLabelProvider(): array
+    {
+        return [
+            ['Red',    'Rot'],
+            ['Yellow', 'Gelb'],
+            ['Green',  'Grün'],
+            ['Blue',   'Blau'],
+            ['Purple', 'Lila'],
+        ];
+    }
+
+    public function testBuildXmpContentLangEnExplicitWritesEnglish(): void
+    {
+        $xmp = $this->service->buildXmpContent(0, 'Green', null, 'en');
+        $this->assertStringContainsString('xmp:Label="Green"', $xmp);
+        $this->assertStringNotContainsString('xmp:Label="Grün"', $xmp);
+    }
+
+    public function testLocalizeLabelHelper(): void
+    {
+        // Static helper: kanonisch EN → DE bei lang='de', sonst EN
+        $this->assertSame('Rot',    XmpService::localizeLabel('Red',    'de'));
+        $this->assertSame('Red',    XmpService::localizeLabel('Red',    'en'));
+        $this->assertSame('Lila',   XmpService::localizeLabel('Purple', 'de'));
+        // Unbekannte Sprache → fällt auf EN zurück
+        $this->assertSame('Red',    XmpService::localizeLabel('Red',    'fr'));
+    }
+
+    /** @dataProvider xmpDmPickProvider */
+    public function testParseXmpDmPick(string $pickVal, string $expected): void
+    {
+        $result = $this->service->parseXmpContent("xmpDM:pick='{$pickVal}'");
+        $this->assertSame($expected, $result['pick']);
+    }
+
+    public static function xmpDmPickProvider(): array
+    {
+        return [
+            'pick (1)'    => ['1',  'pick'],
+            'reject (-1)' => ['-1', 'reject'],
+            'none (0)'    => ['0',  'none'],
+            'invalid (2)' => ['2',  'none'],
+        ];
+    }
+
+    public function testParseXmpDmPickElementForm(): void
+    {
+        $result = $this->service->parseXmpContent('<xmpDM:pick>1</xmpDM:pick>');
+        $this->assertSame('pick', $result['pick']);
+    }
+
+    public function testParseFlashViewIsPickedReadsAsPick(): void
+    {
+        // Rückwärtskompatibel: alte FlashView-Schreibweise wird beim Lesen erkannt
+        $result = $this->service->parseXmpContent("flashView:IsPicked='True'");
+        $this->assertSame('pick', $result['pick']);
+    }
+
+    public function testParseFlashViewIsRejectedReadsAsReject(): void
+    {
+        $result = $this->service->parseXmpContent("flashView:IsRejected='True'");
+        $this->assertSame('reject', $result['pick']);
+    }
+
+    public function testXmpDmPickTakesPriorityOverFlashView(): void
+    {
+        // Wenn beide gesetzt sind: xmpDM gewinnt (FlashView ist nur Fallback)
+        $xmp    = "xmpDM:pick='-1' flashView:IsPicked='True'";
+        $result = $this->service->parseXmpContent($xmp);
+        $this->assertSame('reject', $result['pick']);
+    }
+
+    public function testParseXmpContentEmptyReturnsNonePick(): void
+    {
+        $result = $this->service->parseXmpContent('<x:xmpmeta/>');
+        $this->assertSame('none', $result['pick']);
+    }
+
     // ─── Tests: Round-Trip (bauen + parsen) ───────────────────────────────────
 
     /** @dataProvider roundTripProvider */
-    public function testBuildAndParseRoundTrip(int $rating, ?string $label): void
+    public function testBuildAndParseRoundTrip(int $rating, ?string $label, ?string $pick = null): void
     {
-        $xmp    = $this->service->buildXmpContent($rating, $label);
+        $xmp    = $this->service->buildXmpContent($rating, $label, $pick);
         $result = $this->service->parseXmpContent($xmp);
 
         $this->assertSame($rating, $result['rating']);
         $this->assertSame($label,  $result['label']);
+        $this->assertSame($pick ?? 'none', $result['pick']);
     }
 
     public static function roundTripProvider(): array
     {
         return [
-            [0, null],
-            [1, null],
-            [5, 'Red'],
-            [3, 'Purple'],
-            [4, 'Green'],
+            [0, null,     null],
+            [1, null,     'pick'],
+            [5, 'Red',    'pick'],
+            [3, 'Purple', 'reject'],
+            [4, 'Green',  'none'],
+            [2, 'Blue',   null],
         ];
     }
 


### PR DESCRIPTION
Closes #69

## Summary

XMP write path is now Lightroom-, Bridge- and digiKam-compatible across the full color-rating + pick/reject feature set.

Three independent changes bundled because they all touch the same write path (`XmpService::buildXmpContent`, `ExifService::patchXmpString`):

### 1. `photoshop:LabelColor` is written parallel to `xmp:Label`

LR Classic 7+ reads `photoshop:LabelColor` (lowercase EN) with priority over `xmp:Label` to derive the color stripe. Previously we only wrote `xmp:Label`, and the patch path did not strip a stale `photoshop:LabelColor` left behind by LR — so a re-import in LR would show the **old** color, ignoring our change.

- `XmpService::buildXmpContent` now emits both fields when a label is set
- `ExifService::patchXmpString` strips stale `photoshop:LabelColor` (attribute + element form) before re-injecting
- `xmlns:photoshop` is added to the target rdf:Description block when missing

### 2. Pick/Reject is now written to XMP as `xmpDM:pick` + `xmpDM:good`

Previously stored only in NC Collaborative Tags. Bridge/LRC/digiKam standard:

- `pick` → `xmpDM:pick="1"` + `xmpDM:good="true"`
- `reject` → `xmpDM:pick="-1"` + `xmpDM:good="false"`
- `none` → both attributes removed entirely

Read path is backward-compatible with the older FlashView schema (`flashView:IsPicked`/`IsRejected`); the write path actively cleans up those legacy attributes plus the orphan `xmlns:flashView` namespace declaration.

### 3. New personal setting "Color rating compatible with"

Closes the German-LRC use-case from #69. Two options:

- **Lightroom (German localization)** → writes `xmp:Label="Rot"` etc. so DE-LRC matches its native label set strings
- **Bridge / digiKam / English tools** → writes `xmp:Label="Red"` etc.

Default derives from the NC user UI language (`de_*` → DE, otherwise EN), so German users get a working LR import out of the box without touching settings. `photoshop:LabelColor` stays lowercase EN regardless of this setting — that's universal and drives the LR color stripe.

Setting framing is borrowed from FlashView's UI ("compatibility target", not "language").

## Test plan

- [x] PHPUnit: 279/279 (+28 new service tests covering photoshop, xmpDM, flashView cleanup, lang=de)
- [x] Vitest: 418/418 (no JS-level changes besides the settings dropdown)
- [x] Smoke on production (sixpack): color label round-trip with German LRC shows the correct localized label name (no more white "Custom" flag)
- [x] Smoke on production: Pick/Reject visible in `xmpDM:pick` via exiftool
- [x] Smoke on production: language switch (DE ↔ EN) updates `xmp:Label` correctly on next write

## Notes

- Read path on the server still does NOT re-read XMP from a file when the user views it in StarRate; if LR edits the file, you currently need `occ starrate:import-xmp` to pick up the change. That's a separate concern (will track as new issue).
- `ImportXmpCommand` is unchanged — it still imports rating + label from XMP, not pick/reject. Pick import from XMP can be a follow-up if requested.