### PR TITLE
fix(grid): re-measure grid max-height on folder change

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -909,6 +909,14 @@ onMounted(() => {
     gridEl.value.addEventListener('scroll', onScroll, { passive: true })
     resizeObserver = new ResizeObserver(measureContainer)
     resizeObserver.observe(gridEl.value)
+    // Auch den Wrap-Parent beobachten: bei SPA-Folder-Wechsel ändert sich der
+    // Header darüber (Subfolder-Pills tauchen auf/verschwinden), damit auch der
+    // verfügbare Wrap-Bereich. Das gridEl selbst behält seine Größe → der
+    // ResizeObserver darauf feuert nicht. Ohne Parent-Observer bleibt die alte
+    // maxHeight stehen → Grid wirkt zu kurz/zu lang bis zum Reload.
+    if (gridEl.value.parentElement) {
+      resizeObserver.observe(gridEl.value.parentElement)
+    }
   }
   observeAllItems()
   window.addEventListener('resize', syncMaxHeight)


### PR DESCRIPTION
## Summary

When navigating into a subfolder via SPA routing, the grid sometimes only filled ~2/3 of the available viewport height until a manual page reload. The cause: `syncMaxHeight` in `GridView.vue` measures `gridEl.getBoundingClientRect().top` and only re-runs when `gridEl` itself resizes. On folder change, the **header above** the grid changes (subfolder pills appear/disappear, breadcrumb segments shift), which moves the grid vertically without changing its own size — so the existing `ResizeObserver` on `gridEl` stayed silent and the cached `maxHeight` was wrong for the new layout.

## Fix

Register the `ResizeObserver` additionally on `gridEl.parentElement` (`.sr-view-wrap`). When the header above grows or shrinks, the wrap's available area changes accordingly → observer fires → `measureContainer` re-runs `syncMaxHeight` with the fresh top position.

Loop-safe: our `style.maxHeight` mutation does not change the parent (it's `flex: 1`), so this can't trigger a feedback loop.

## Test plan

- [x] Vitest GridView: 52/52 still green (no behavioral changes to the existing observer setup)
- [x] Smoke on production: navigating into a subfolder no longer shows the truncated grid; height fits the viewport without reload