### PR TITLE
fix(nc34): replace removed OC\Server::getURLGenerator() with OCP\Server::get()

### DIFF
--- a/templates/guest.php
+++ b/templates/guest.php
@@ -11,7 +11,7 @@ $allowComment = $_['allow_comment'] ?? false;
 $guestName    = $_['guest_name']    ?? '';
 
 // Server-URL für den App Deep Link (starrate://guest?token=...&server=...)
-$serverUrl = \OC::$server->getURLGenerator()->getAbsoluteURL('/');
+$serverUrl = \OCP\Server::get(\OCP\IURLGenerator::class)->getAbsoluteURL('/');
 $serverUrl = rtrim($serverUrl, '/');
 ?>
 <div

--- a/templates/index.php
+++ b/templates/index.php
@@ -5,4 +5,4 @@
 \OCP\Util::addStyle('starrate', 'starrate-main');
 ?>
 <div id="starrate-root"
-     data-nc-url="<?= \OC::$server->getURLGenerator()->getBaseUrl() ?>"></div>
+     data-nc-url="<?= \OCP\Server::get(\OCP\IURLGenerator::class)->getBaseUrl() ?>"></div>


### PR DESCRIPTION
## Summary

- Replace two direct calls to `\OC::$server->getURLGenerator()` (removed in Nextcloud 34) with the supported DI-based `\OCP\Server::get(\OCP\IURLGenerator::class)`.
- Affected: `templates/index.php` (logged-in app shell) and `templates/guest.php` (guest gallery deep-link URL).

Without this fix StarRate throws a fatal `Call to undefined method OC\Server::getURLGenerator()` on Nextcloud 34, even though `info.xml` already declares `max-version="34"` — so the app was effectively unusable on the latest NC release.

## Backwards compatibility

`\OCP\Server::get()` is available since Nextcloud 25, so the fix covers the full supported range (NC 29–34).

Closes #75

Thanks to @miaulalala for the report and the spot-on suggested fix.

## Test plan

- [ ] Verify app still loads on NC 31 / 33 (existing test instances)
- [ ] Verify app loads cleanly on NC 34 — no more `Call to undefined method`
- [ ] Verify guest share link still embeds the deep-link `starrate://` server URL correctly