### PR TITLE
fix: write guest ratings into JPEG XMP + legacy heal command

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -96,6 +96,12 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
         <nextcloud min-version="29" max-version="34"/>
     </dependencies>
 
+    <repair-steps>
+        <post-migration>
+            <step>OCA\StarRate\Migration\GuestXmpDriftWarning</step>
+        </post-migration>
+    </repair-steps>
+
     <navigations>
         <navigation>
             <name>StarRate</name>
@@ -107,6 +113,7 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 
     <commands>
         <command>OCA\StarRate\Command\ImportXmpCommand</command>
+        <command>OCA\StarRate\Command\HealGuestXmpCommand</command>
     </commands>
 
     <settings>

--- a/lib/Command/HealGuestXmpCommand.php
+++ b/lib/Command/HealGuestXmpCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\StarRate\Command;
+
+use OCA\StarRate\Service\ShareService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * occ starrate:heal-guest-xmp [--user=<uid>] [--write]
+ *
+ * Heilt gast-bewertete JPEGs, deren DB-Tag und JPEG-XMP durch die alte
+ * „Gast schreibt kein XMP"-Lücke (vor dem Fix) auseinanderlaufen — und die das
+ * Self-Healing sonst beim Öffnen auf den veralteten XMP-Wert zurücksetzt.
+ *
+ * Quelle ist das Gast-Log. Konfliktsicher: nur Dateien, die NACH der Gast-Bewertung
+ * nicht extern (LR/digiKam) bearbeitet wurden (Datei-mtime ≤ Log-Zeit).
+ *
+ * Default = Dry-Run (zeigt nur an). --write schreibt DB + XMP.
+ */
+class HealGuestXmpCommand extends Command
+{
+    public function __construct(
+        private readonly ShareService $shareService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('starrate:heal-guest-xmp')
+            ->setDescription('Heal guest ratings that never reached the JPEG XMP (legacy drift fix)')
+            ->addOption(
+                'user', 'u',
+                InputOption::VALUE_REQUIRED,
+                'Limit to one Nextcloud user (share owner). Default: all share owners.'
+            )
+            ->addOption(
+                'write', null,
+                InputOption::VALUE_NONE,
+                'Actually write DB + XMP. Default: dry-run, no changes.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $write  = (bool) $input->getOption('write');
+        $userId = $input->getOption('user');
+
+        $owners = ($userId !== null && $userId !== '')
+            ? [$userId]
+            : $this->shareService->getAllShareOwners();
+        if (empty($owners)) {
+            $output->writeln('<comment>No StarRate share owners found — nothing to heal.</comment>');
+            return Command::SUCCESS;
+        }
+
+        if (!$write) {
+            $output->writeln('<comment>[dry-run] No changes will be written. Pass --write to heal.</comment>');
+        }
+
+        $grand = [
+            'folded' => 0, 'candidates' => 0, 'healed' => 0, 'skipped_mtime' => 0,
+            'in_sync' => 0, 'non_jpeg' => 0, 'not_found' => 0, 'errors' => 0,
+        ];
+
+        foreach ($owners as $owner) {
+            $report = $this->shareService->healGuestXmp($owner, $write);
+
+            if ($report['write_xmp'] === false) {
+                $output->writeln(sprintf(
+                    'User <info>%s</info>: write_xmp disabled — skipped (no drift possible).',
+                    $owner
+                ));
+                continue;
+            }
+
+            $s = $report['stats'];
+            foreach (array_keys($grand) as $k) {
+                $grand[$k] += $s[$k];
+            }
+
+            $output->writeln(sprintf(
+                'User <info>%s</info>: %d guest-rated, %d %s, %d in sync, %d edited-later, %d non-JPEG, %d gone, %d errors.',
+                $owner,
+                $s['folded'],
+                $write ? $s['healed'] : $s['candidates'],
+                $write ? 'healed' : 'to heal',
+                $s['in_sync'],
+                $s['skipped_mtime'],
+                $s['non_jpeg'],
+                $s['not_found'],
+                $s['errors']
+            ));
+
+            foreach ($report['details'] as $d) {
+                $output->writeln(sprintf(
+                    '    %s %s  guest[%s] ← xmp[%s]',
+                    $write ? '<info>heal</info>' : '<comment>would heal</comment>',
+                    $d['name'],
+                    $this->fmt($d['guest']),
+                    $this->fmt($d['xmp'])
+                ));
+            }
+        }
+
+        $output->writeln(sprintf(
+            '%s<comment>Total:</comment> %d %s across %d guest-rated files (%d skipped as edited-later, %d errors).',
+            $write ? '' : '[dry-run] ',
+            $write ? $grand['healed'] : $grand['candidates'],
+            $write ? 'healed' : 'to heal',
+            $grand['folded'],
+            $grand['skipped_mtime'],
+            $grand['errors']
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Formatiert ein {rating,color,pick}-Tripel kompakt für die Ausgabe.
+     * null = vom Gast nicht gesetzt (–), '' = Farbe gelöscht (no-color).
+     *
+     * @param array{rating: int|null, color: string|null, pick: string|null} $v
+     */
+    private function fmt(array $v): string
+    {
+        $r = $v['rating'] === null ? '–' : ($v['rating'] . '★');
+        $c = ($v['color'] ?? null) === null ? '–' : ($v['color'] === '' ? 'no-color' : $v['color']);
+        $p = ($v['pick'] ?? null) === null ? '–' : $v['pick'];
+        return "{$r} {$c} {$p}";
+    }
+}

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -396,7 +396,17 @@ class ShareController extends Controller
         }
 
         $rating    = isset($body['rating']) ? (int) $body['rating'] : null;
-        $color     = isset($body['color']) && $body['color'] !== null ? ucfirst(strtolower($body['color'])) : null;
+        // color: Key vorhanden + null/'' = löschen (''), Key vorhanden + Wert = setzen,
+        // Key fehlt = unverändert (null). array_key_exists statt isset, sonst würde ein
+        // explizites null (Gast entfernt die Farbe) als „unverändert" verschluckt.
+        if (array_key_exists('color', $body)) {
+            $rawColor = $body['color'];
+            $color    = ($rawColor === null || $rawColor === '')
+                ? ''
+                : ucfirst(strtolower((string) $rawColor));
+        } else {
+            $color = null;
+        }
         $pick      = !empty($share['allow_pick']) ? ($body['pick'] ?? null) : null;
         $guestName = trim($body['guest_name'] ?? 'Gast');
 

--- a/lib/Migration/GuestXmpDriftWarning.php
+++ b/lib/Migration/GuestXmpDriftWarning.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\StarRate\Migration;
+
+use OCA\StarRate\Service\ShareService;
+use OCA\StarRate\Settings\UserSettings;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Warnt beim App-Upgrade, wenn gast-bewertete Dateien existieren, deren XMP durch die
+ * alte „Gast schreibt kein XMP"-Lücke driften könnte.
+ *
+ * Schreibt bewusst NICHTS (keine stillen JPEG-Änderungen beim Upgrade) — die
+ * eigentliche, konfliktsichere Heilung läuft transparent per `occ starrate:heal-guest-xmp`
+ * (Dry-Run-Default). Der Scan ist günstig: nur Config-Reads, kein Datei-I/O.
+ */
+class GuestXmpDriftWarning implements IRepairStep
+{
+    public function __construct(
+        private readonly ShareService $shareService,
+        private readonly UserSettings $userSettings,
+    ) {}
+
+    public function getName(): string
+    {
+        return 'StarRate: check guest ratings for XMP drift';
+    }
+
+    public function run(IOutput $output): void
+    {
+        $atRisk   = 0;
+        $affected = 0;
+
+        foreach ($this->shareService->getAllShareOwners() as $owner) {
+            // Kein write_xmp → kein Self-Healing → kein Drift möglich.
+            if (!$this->userSettings->getSettings($owner)['write_xmp']) {
+                continue;
+            }
+            $n = $this->shareService->countGuestRatedFiles($owner);
+            if ($n > 0) {
+                $atRisk += $n;
+                $affected++;
+            }
+        }
+
+        if ($atRisk === 0) {
+            return;
+        }
+
+        $output->warning(sprintf(
+            'StarRate: up to %d guest-rated file(s) across %d user(s) may have ratings not yet written '
+            . 'to their JPEG XMP. Run "occ starrate:heal-guest-xmp" to review (dry-run), '
+            . 'then add "--write" to heal.',
+            $atRisk,
+            $affected
+        ));
+    }
+}

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OCA\StarRate\Service;
 
+use OCA\StarRate\Settings\UserSettings;
 use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -45,6 +46,8 @@ class ShareService
         private readonly TagService      $tagService,
         private readonly LoggerInterface $logger,
         private readonly IDBConnection $db,
+        private readonly ExifService     $exifService,
+        private readonly UserSettings    $userSettings,
     ) {}
 
     // ─── Share erstellen / verwalten ─────────────────────────────────────────
@@ -411,13 +414,16 @@ class ShareService
             $metadata['rating'] = $rating;
         }
         if ($color !== null) {
-            $metadata['color'] = $color;
+            // '' = Gast hat die Farbe gelöscht → null für setMetadata (= Tag entfernen).
+            // writeGuestXmp bekommt $color unverändert ('' = Label im XMP entfernen).
+            $metadata['color'] = $color === '' ? null : $color;
         }
         if ($pick !== null) {
             $metadata['pick'] = $pick;
         }
         if (!empty($metadata)) {
             $this->tagService->setMetadata($fileIdStr, $metadata);
+            $this->writeGuestXmp($ownerId, $fileId, $rating, $color, $pick);
         }
 
         $filename = $this->resolveFilename($ownerId, $fileId);
@@ -674,6 +680,255 @@ class ShareService
             }
         } catch (\Exception) { /* ignore */ }
         return (string) $fileId;
+    }
+
+    /**
+     * Schreibt eine Gast-Bewertung zusätzlich ins JPEG-XMP — analog zum normalen
+     * User-Rating in RatingController::set.
+     *
+     * Maßgeblich ist die write_xmp-Einstellung des Share-Owners (der Gast hat keine
+     * eigene Session/Settings). Ohne diesen Schritt bliebe das JPEG-XMP veraltet,
+     * während nur der NC-Tag aktualisiert würde — das Self-Healing beim Owner
+     * (RatingController::get) würde die Gast-Bewertung beim nächsten Öffnen mit dem
+     * alten XMP-Wert überschreiben.
+     *
+     * $rating/$color/$pick haben bereits die writeMetadata-Semantik:
+     *   null = unverändert, '' = entfernen (Label), 'none' = entfernen (Pick).
+     * Non-fatal: schlägt das Schreiben fehl, bleibt der NC-Tag trotzdem gesetzt.
+     */
+    private function writeGuestXmp(string $ownerId, int $fileId, ?int $rating, ?string $color, ?string $pick): void
+    {
+        $file = $this->getOwnerFile($ownerId, $fileId);
+        if ($file === null || !in_array($file->getMimeType(), ['image/jpeg', 'image/jpg'], true)) {
+            return;
+        }
+
+        $settings = $this->userSettings->getSettings($ownerId);
+        if (!$settings['write_xmp']) {
+            return;
+        }
+
+        try {
+            $this->exifService->writeMetadata($file, $rating, $color, $pick, $settings['xmp_label_language']);
+        } catch (\Exception $e) {
+            $this->logger->warning("StarRate: Gast-XMP-Write übersprungen für {$fileId}: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Löst eine file_id in das File-Objekt des Owners auf (null wenn nicht gefunden).
+     */
+    private function getOwnerFile(string $ownerId, int $fileId): ?File
+    {
+        try {
+            $nodes = $this->rootFolder->getUserFolder($ownerId)->getById($fileId);
+            foreach ($nodes as $n) {
+                if ($n instanceof File) {
+                    return $n;
+                }
+            }
+        } catch (\Exception) { /* ignore */ }
+        return null;
+    }
+
+    // ─── Gast-XMP-Heilung (Altbestands-Migration) ─────────────────────────────
+    //
+    // Vor dem Forward-Fix schrieben Gast-Bewertungen nur NC-Tags, nie JPEG-XMP.
+    // Das Self-Healing (RatingController::get) setzt sie dann beim Öffnen auf den
+    // veralteten XMP-Wert zurück. Diese Migration heilt den Altbestand: sie liest
+    // die Gast-Absicht aus dem Gast-Log (nicht der DB — daher auch korrekt, wenn der
+    // Tag bereits gekippt wurde) und schreibt sie zurück in DB + XMP. Konfliktsicher
+    // per Zeitvergleich (Datei-mtime ≤ Log-Zeit), damit ein späterer externer
+    // LR/digiKam-Edit nicht überschrieben wird.
+
+    /**
+     * Liefert alle NC-User-IDs, die mindestens einen StarRate-Share angelegt haben.
+     * Direkte preferences-Abfrage — vermeidet teures Iterieren über alle NC-User.
+     *
+     * @return string[]
+     */
+    public function getAllShareOwners(): array
+    {
+        $qb     = $this->db->getQueryBuilder();
+        $result = $qb->selectDistinct('userid')
+            ->from('preferences')
+            ->where($qb->expr()->eq('appid', $qb->createNamedParameter(self::APP_ID)))
+            ->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter(self::CONFIG_SHARES)))
+            ->executeQuery();
+
+        $owners = [];
+        while ($row = $result->fetch()) {
+            $owners[] = (string) $row['userid'];
+        }
+        $result->closeCursor();
+        return $owners;
+    }
+
+    /**
+     * Faltet alle Gast-Logs eines Owners pro file_id zur kumulativen Gast-Absicht.
+     *
+     * Jeder Log-Eintrag ist ein Delta — nur die im jeweiligen Request gesetzten Felder
+     * sind non-null. Chronologisch gefaltet: letztes non-null je Feld gewinnt, `ts` =
+     * jüngster beteiligter Zeitstempel. rating=0 / color='' / pick='none' sind bewusste
+     * Lösch-Werte (non-null) und überschreiben entsprechend.
+     *
+     * @return array<int, array{rating: int|null, color: string|null, pick: string|null, ts: int}>
+     */
+    public function foldGuestLog(string $ownerId): array
+    {
+        // Erst ALLE Einträge aller Shares einsammeln, dann GLOBAL chronologisch sortieren.
+        // Pro-Token-Sortierung würde bei derselben Datei über zwei Share-Tokens die
+        // Share-Reihenfolge statt des Zeitstempels über den Gewinner entscheiden.
+        $entries = [];
+        foreach (array_keys($this->loadAllShares($ownerId)) as $token) {
+            $raw = $this->config->getUserValue($ownerId, self::APP_ID, self::CONFIG_LOG . '_' . $token, '[]');
+            $log = json_decode($raw, true);
+            if (!is_array($log)) {
+                continue;
+            }
+            foreach ($log as $e) {
+                if (is_array($e)) {
+                    $entries[] = $e;
+                }
+            }
+        }
+        usort($entries, static fn(array $a, array $b): int => ($a['timestamp'] ?? 0) <=> ($b['timestamp'] ?? 0));
+
+        $folded = [];
+        foreach ($entries as $e) {
+            $fileId = (int) ($e['file_id'] ?? 0);
+            if ($fileId <= 0) {
+                continue;
+            }
+            if (!isset($folded[$fileId])) {
+                $folded[$fileId] = ['rating' => null, 'color' => null, 'pick' => null, 'ts' => 0];
+            }
+            if (($e['rating'] ?? null) !== null) $folded[$fileId]['rating'] = (int) $e['rating'];
+            if (($e['color']  ?? null) !== null) $folded[$fileId]['color']  = (string) $e['color'];
+            if (($e['pick']   ?? null) !== null) $folded[$fileId]['pick']   = (string) $e['pick'];
+            $ts = (int) ($e['timestamp'] ?? 0);
+            if ($ts > $folded[$fileId]['ts']) {
+                $folded[$fileId]['ts'] = $ts;
+            }
+        }
+
+        // Phantom-Einträge (Request ohne rating/color/pick) verwerfen — keine Gast-Absicht,
+        // würden sonst Repair-Warnung + Heal-Scan unnötig aufblähen.
+        return array_filter(
+            $folded,
+            static fn(array $f): bool => $f['rating'] !== null || $f['color'] !== null || $f['pick'] !== null
+        );
+    }
+
+    /**
+     * Zählt die gast-bewerteten Dateien eines Owners (obere Schranke, kein Datei-I/O).
+     * Für den Repair-Step-Scan beim Upgrade.
+     */
+    public function countGuestRatedFiles(string $ownerId): int
+    {
+        return count($this->foldGuestLog($ownerId));
+    }
+
+    /**
+     * Analysiert (Dry-Run) oder heilt gast-bewertete JPEGs eines Owners, deren DB/XMP
+     * durch die alte „Gast schreibt kein XMP"-Lücke auseinanderlaufen.
+     *
+     * Nur aktiv wenn der Owner write_xmp aktiviert hat (sonst kein Self-Healing → kein Drift).
+     * Pro Datei: mtime-Guard (extern später bearbeitet → übersprungen), dann XMP-Vergleich
+     * gegen die Gast-Absicht; bei Abweichung Kandidat (Dry-Run) bzw. DB+XMP-Write (--write).
+     *
+     * @param bool $write false = Analyse, true = DB+XMP tatsächlich schreiben.
+     * @return array{write_xmp: bool, stats: array<string,int>, details: array<int, array>}
+     */
+    public function healGuestXmp(string $ownerId, bool $write): array
+    {
+        $stats = [
+            'folded'        => 0,
+            'candidates'    => 0,
+            'healed'        => 0,
+            'skipped_mtime' => 0,
+            'in_sync'       => 0,
+            'non_jpeg'      => 0,
+            'not_found'     => 0,
+            'errors'        => 0,
+        ];
+        $details = [];
+
+        $settings = $this->userSettings->getSettings($ownerId);
+        if (!$settings['write_xmp']) {
+            return ['write_xmp' => false, 'stats' => $stats, 'details' => $details];
+        }
+        $lang = $settings['xmp_label_language'];
+
+        $folded          = $this->foldGuestLog($ownerId);
+        $stats['folded'] = count($folded);
+
+        foreach ($folded as $fileId => $g) {
+            $file = $this->getOwnerFile($ownerId, $fileId);
+            if ($file === null) {
+                $stats['not_found']++;
+                continue;
+            }
+            if (!in_array($file->getMimeType(), ['image/jpeg', 'image/jpg'], true)) {
+                $stats['non_jpeg']++;
+                continue;
+            }
+            // Konflikt-Guard: Datei nach der Gast-Bewertung extern bearbeitet → in Ruhe lassen.
+            if ($file->getMTime() > $g['ts']) {
+                $stats['skipped_mtime']++;
+                continue;
+            }
+
+            try {
+                $xmp = $this->exifService->readMetadata($file);
+            } catch (\Exception $e) {
+                $stats['errors']++;
+                $this->logger->warning("StarRate heal: XMP-Read fehlgeschlagen für {$fileId}: " . $e->getMessage());
+                continue;
+            }
+
+            // Nur die Felder vergleichen, die der Gast tatsächlich gesetzt hat.
+            $targetColor = $g['color'] === '' ? null : $g['color'];
+            $targetPick  = $g['pick']  === '' ? 'none' : $g['pick'];
+            $diff = false;
+            if ($g['rating'] !== null && $xmp['rating'] !== $g['rating'])          $diff = true;
+            if ($g['color']  !== null && ($xmp['label'] ?? null) !== $targetColor) $diff = true;
+            if ($g['pick']   !== null && $xmp['pick'] !== $targetPick)             $diff = true;
+
+            if (!$diff) {
+                $stats['in_sync']++;
+                continue;
+            }
+
+            $stats['candidates']++;
+            $details[] = [
+                'file_id' => $fileId,
+                'name'    => $file->getName(),
+                'guest'   => ['rating' => $g['rating'], 'color' => $g['color'], 'pick' => $g['pick']],
+                'xmp'     => ['rating' => $xmp['rating'], 'color' => $xmp['label'] ?? null, 'pick' => $xmp['pick']],
+            ];
+
+            if (!$write) {
+                continue;
+            }
+
+            try {
+                $dbData = [];
+                if ($g['rating'] !== null) $dbData['rating'] = $g['rating'];
+                if ($g['color']  !== null) $dbData['color']  = $targetColor;
+                if ($g['pick']   !== null) $dbData['pick']   = $targetPick;
+                if (!empty($dbData)) {
+                    $this->tagService->setMetadata((string) $fileId, $dbData);
+                }
+                $this->exifService->writeMetadata($file, $g['rating'], $g['color'], $g['pick'], $lang);
+                $stats['healed']++;
+            } catch (\Exception $e) {
+                $stats['errors']++;
+                $this->logger->warning("StarRate heal: Schreiben fehlgeschlagen für {$fileId}: " . $e->getMessage());
+            }
+        }
+
+        return ['write_xmp' => true, 'stats' => $stats, 'details' => $details];
     }
 
     /**

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace OCA\StarRate\Tests\Unit\Service;
 
+use OCA\StarRate\Service\ExifService;
 use OCA\StarRate\Service\ShareService;
 use OCA\StarRate\Service\TagService;
+use OCA\StarRate\Settings\UserSettings;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -53,6 +55,8 @@ class ShareServiceTest extends TestCase
             $this->createMock(TagService::class),
             $this->createMock(LoggerInterface::class),
             $this->db,
+            $this->createMock(ExifService::class),
+            $this->createMock(UserSettings::class),
         );
     }
 
@@ -311,6 +315,428 @@ class ShareServiceTest extends TestCase
         $this->assertCount(1, $saved);
         $this->assertSame('Anna', $saved[0]['guest_name']);
         $this->assertSame(42, $saved[0]['file_id']);
+    }
+
+    // ─── Tests: Gast-Bewertung schreibt JPEG-XMP (Owner-Setting maßgeblich) ─────
+
+    public function testSaveGuestRatingWritesXmpWhenOwnerWriteXmpEnabled(): void
+    {
+        $share = ['token' => self::SAMPLE_TOKEN, 'owner_id' => self::OWNER_ID];
+        $file  = $this->jpegFileMock();
+
+        $exif = $this->createMock(ExifService::class);
+        // rating=4, color='Green', pick=null, lang aus Owner-Settings
+        $exif->expects($this->once())
+            ->method('writeMetadata')
+            ->with($file, 4, 'Green', null, 'en');
+
+        $service = $this->makeServiceForXmp(
+            $this->rootFolderReturning($file),
+            $exif,
+            $this->settingsMock(true, 'en'),
+        );
+
+        $service->saveGuestRating($share, 42, 4, 'Green', null, 'Anna');
+    }
+
+    public function testSaveGuestRatingSkipsXmpWhenWriteXmpDisabled(): void
+    {
+        $share = ['token' => self::SAMPLE_TOKEN, 'owner_id' => self::OWNER_ID];
+
+        $exif = $this->createMock(ExifService::class);
+        $exif->expects($this->never())->method('writeMetadata');
+
+        $service = $this->makeServiceForXmp(
+            $this->rootFolderReturning($this->jpegFileMock()),
+            $exif,
+            $this->settingsMock(false),
+        );
+
+        $service->saveGuestRating($share, 42, 4, 'Green', null, 'Anna');
+    }
+
+    public function testSaveGuestRatingSkipsXmpForNonJpeg(): void
+    {
+        $share = ['token' => self::SAMPLE_TOKEN, 'owner_id' => self::OWNER_ID];
+
+        $png = $this->createMock(File::class);
+        $png->method('getMimeType')->willReturn('image/png');
+        $png->method('getName')->willReturn('photo.png');
+
+        $exif = $this->createMock(ExifService::class);
+        $exif->expects($this->never())->method('writeMetadata');
+
+        $service = $this->makeServiceForXmp(
+            $this->rootFolderReturning($png),
+            $exif,
+            $this->settingsMock(true),
+        );
+
+        $service->saveGuestRating($share, 42, 4, 'Green', null, 'Anna');
+    }
+
+    public function testSaveGuestRatingXmpFailureIsNonFatal(): void
+    {
+        $share = ['token' => self::SAMPLE_TOKEN, 'owner_id' => self::OWNER_ID];
+
+        $exif = $this->createMock(ExifService::class);
+        $exif->method('writeMetadata')->willThrowException(new \RuntimeException('disk full'));
+
+        $service = $this->makeServiceForXmp(
+            $this->rootFolderReturning($this->jpegFileMock()),
+            $exif,
+            $this->settingsMock(true),
+        );
+
+        // Trotz XMP-Fehler liefert saveGuestRating ein gültiges Ergebnis (Tag bleibt gesetzt).
+        $result = $service->saveGuestRating($share, 42, 4, 'Green', null, 'Anna');
+        $this->assertSame(4, $result['rating']);
+    }
+
+    private function jpegFileMock(): File
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getMimeType')->willReturn('image/jpeg');
+        $file->method('getName')->willReturn('photo.jpg');
+        return $file;
+    }
+
+    private function rootFolderReturning(?File $file): IRootFolder
+    {
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getById')->willReturn($file === null ? [] : [$file]);
+        $rootFolder = $this->createMock(IRootFolder::class);
+        $rootFolder->method('getUserFolder')->willReturn($folder);
+        return $rootFolder;
+    }
+
+    private function settingsMock(bool $writeXmp, string $lang = 'en'): UserSettings
+    {
+        $us = $this->createMock(UserSettings::class);
+        $us->method('getSettings')->willReturn([
+            'write_xmp'          => $writeXmp,
+            'xmp_label_language' => $lang,
+        ]);
+        return $us;
+    }
+
+    // ─── Tests: Altbestands-Heilung (foldGuestLog / healGuestXmp) ─────────────
+
+    public function testFoldGuestLogMergesDeltasPerFile(): void
+    {
+        $service = $this->makeHealService(
+            $this->healConfig([
+                ['file_id' => 42, 'rating' => 4,    'color' => null,  'pick' => null, 'timestamp' => 100],
+                ['file_id' => 42, 'rating' => null, 'color' => 'Red', 'pick' => null, 'timestamp' => 200],
+            ]),
+            $this->rootFolderReturning(null),
+            $this->createMock(ExifService::class),
+            $this->settingsMock(true),
+        );
+
+        $folded = $service->foldGuestLog(self::OWNER_ID);
+
+        $this->assertArrayHasKey(42, $folded);
+        $this->assertSame(4,     $folded[42]['rating']);
+        $this->assertSame('Red', $folded[42]['color']);
+        $this->assertNull($folded[42]['pick']);
+        $this->assertSame(200,   $folded[42]['ts']);  // jüngster beteiligter Zeitstempel
+    }
+
+    public function testHealGuestXmpDryRunFindsCandidateWithoutWriting(): void
+    {
+        $exif = $this->createMock(ExifService::class);
+        $exif->method('readMetadata')->willReturn(['rating' => 2, 'label' => null, 'pick' => 'none']);
+        $exif->expects($this->never())->method('writeMetadata');
+
+        $tag = $this->createMock(TagService::class);
+        $tag->expects($this->never())->method('setMetadata');
+
+        $service = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => 4, 'color' => null, 'pick' => null, 'timestamp' => 100]]),
+            $this->rootFolderReturning($this->healFile(50)),
+            $exif,
+            $this->settingsMock(true),
+            $tag,
+        );
+
+        $report = $service->healGuestXmp(self::OWNER_ID, false);
+
+        $this->assertTrue($report['write_xmp']);
+        $this->assertSame(1, $report['stats']['candidates']);
+        $this->assertSame(0, $report['stats']['healed']);
+        $this->assertCount(1, $report['details']);
+    }
+
+    public function testHealGuestXmpWriteHealsDbAndXmp(): void
+    {
+        $exif = $this->createMock(ExifService::class);
+        $exif->method('readMetadata')->willReturn(['rating' => 2, 'label' => null, 'pick' => 'none']);
+        $exif->expects($this->once())
+            ->method('writeMetadata')
+            ->with($this->isInstanceOf(File::class), 4, null, null, 'en');
+
+        $tag = $this->createMock(TagService::class);
+        $tag->expects($this->once())
+            ->method('setMetadata')
+            ->with('42', ['rating' => 4]);
+
+        $service = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => 4, 'color' => null, 'pick' => null, 'timestamp' => 100]]),
+            $this->rootFolderReturning($this->healFile(50)),
+            $exif,
+            $this->settingsMock(true, 'en'),
+            $tag,
+        );
+
+        $report = $service->healGuestXmp(self::OWNER_ID, true);
+
+        $this->assertSame(1, $report['stats']['healed']);
+    }
+
+    public function testHealGuestXmpSkipsFileEditedAfterGuest(): void
+    {
+        $exif = $this->createMock(ExifService::class);
+        $exif->expects($this->never())->method('readMetadata');
+        $exif->expects($this->never())->method('writeMetadata');
+
+        $service = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => 4, 'color' => null, 'pick' => null, 'timestamp' => 100]]),
+            $this->rootFolderReturning($this->healFile(200)),  // mtime 200 > ts 100 → extern später bearbeitet
+            $exif,
+            $this->settingsMock(true),
+        );
+
+        $report = $service->healGuestXmp(self::OWNER_ID, true);
+
+        $this->assertSame(1, $report['stats']['skipped_mtime']);
+        $this->assertSame(0, $report['stats']['candidates']);
+    }
+
+    public function testHealGuestXmpSkipsWhenAlreadyInSync(): void
+    {
+        $exif = $this->createMock(ExifService::class);
+        $exif->method('readMetadata')->willReturn(['rating' => 4, 'label' => null, 'pick' => 'none']);
+        $exif->expects($this->never())->method('writeMetadata');
+
+        $service = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => 4, 'color' => null, 'pick' => null, 'timestamp' => 100]]),
+            $this->rootFolderReturning($this->healFile(50)),
+            $exif,
+            $this->settingsMock(true),
+        );
+
+        $report = $service->healGuestXmp(self::OWNER_ID, true);
+
+        $this->assertSame(1, $report['stats']['in_sync']);
+        $this->assertSame(0, $report['stats']['candidates']);
+    }
+
+    public function testHealGuestXmpSkipsOwnerWithWriteXmpDisabled(): void
+    {
+        $rootFolder = $this->createMock(IRootFolder::class);
+        $rootFolder->expects($this->never())->method('getUserFolder');
+
+        $report = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => 4, 'color' => null, 'pick' => null, 'timestamp' => 100]]),
+            $rootFolder,
+            $this->createMock(ExifService::class),
+            $this->settingsMock(false),
+        )->healGuestXmp(self::OWNER_ID, true);
+
+        $this->assertFalse($report['write_xmp']);
+        $this->assertSame(0, $report['stats']['folded']);
+    }
+
+    public function testFoldGuestLogGlobalOrderAcrossTokens(): void
+    {
+        // Dieselbe Datei über zwei Tokens: neuerer Wert (ts 100) steht im zuerst
+        // gelisteten Token, älterer (ts 50) im zweiten. Globale Sortierung muss den
+        // jüngsten gewinnen lassen — unabhängig von der Token-Reihenfolge.
+        $configMap = [
+            'starrate_shares' => json_encode([
+                'TOKA' => ['token' => 'TOKA', 'owner_id' => self::OWNER_ID],
+                'TOKB' => ['token' => 'TOKB', 'owner_id' => self::OWNER_ID],
+            ]),
+            'starrate_guest_log_TOKA' => json_encode([
+                ['file_id' => 42, 'rating' => 5, 'color' => null, 'pick' => null, 'timestamp' => 100],
+            ]),
+            'starrate_guest_log_TOKB' => json_encode([
+                ['file_id' => 42, 'rating' => 2, 'color' => null, 'pick' => null, 'timestamp' => 50],
+            ]),
+        ];
+
+        $folded = $this->makeHealService(
+            $configMap,
+            $this->rootFolderReturning(null),
+            $this->createMock(ExifService::class),
+            $this->settingsMock(true),
+        )->foldGuestLog(self::OWNER_ID);
+
+        $this->assertSame(5,   $folded[42]['rating']);  // jüngster gewinnt, nicht der Token-Reihenfolge nach
+        $this->assertSame(100, $folded[42]['ts']);
+    }
+
+    public function testFoldGuestLogDropsPhantomEntries(): void
+    {
+        // Request nur mit file_id (keine Bewertung) → kein Gast-Intent → kein Eintrag.
+        $folded = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => null, 'color' => null, 'pick' => null, 'timestamp' => 100]]),
+            $this->rootFolderReturning(null),
+            $this->createMock(ExifService::class),
+            $this->settingsMock(true),
+        )->foldGuestLog(self::OWNER_ID);
+
+        $this->assertSame([], $folded);
+    }
+
+    public function testHealGuestXmpClearsPickViaNormalizedValue(): void
+    {
+        // Gast hat Pick zurückgenommen (pick='none'); XMP trägt noch 'pick'.
+        $exif = $this->createMock(ExifService::class);
+        $exif->method('readMetadata')->willReturn(['rating' => 0, 'label' => null, 'pick' => 'pick']);
+        $exif->expects($this->once())
+            ->method('writeMetadata')
+            ->with($this->isInstanceOf(File::class), null, null, 'none', 'en');
+
+        $tag = $this->createMock(TagService::class);
+        $tag->expects($this->once())
+            ->method('setMetadata')
+            ->with('42', ['pick' => 'none']);   // normalisiert, kein '' → keine Validierungs-Exception
+
+        $service = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => null, 'color' => null, 'pick' => 'none', 'timestamp' => 100]]),
+            $this->rootFolderReturning($this->healFile(50)),
+            $exif,
+            $this->settingsMock(true, 'en'),
+            $tag,
+        );
+
+        $report = $service->healGuestXmp(self::OWNER_ID, true);
+
+        $this->assertSame(1, $report['stats']['healed']);
+    }
+
+    public function testSaveGuestRatingColorClearRemovesFromDbAndXmp(): void
+    {
+        // Gast entfernt die Farbe → color='' erreicht saveGuestRating.
+        $exif = $this->createMock(ExifService::class);
+        $exif->expects($this->once())
+            ->method('writeMetadata')
+            ->with($this->isInstanceOf(File::class), null, '', null, 'en');  // '' = Label entfernen
+
+        $tag = $this->createMock(TagService::class);
+        $tag->expects($this->once())
+            ->method('setMetadata')
+            ->with('42', ['color' => null]);  // '' → null = Tag entfernen
+
+        $service = $this->makeHealService(
+            [],
+            $this->rootFolderReturning($this->healFile(50)),
+            $exif,
+            $this->settingsMock(true, 'en'),
+            $tag,
+        );
+
+        $service->saveGuestRating(
+            ['token' => self::SAMPLE_TOKEN, 'owner_id' => self::OWNER_ID],
+            42, null, '', null, 'Anna'
+        );
+    }
+
+    public function testHealGuestXmpClearsColorViaEmptyString(): void
+    {
+        // Gast-Log trägt color='' (gelöscht); XMP hat noch ein Label 'Red'.
+        $exif = $this->createMock(ExifService::class);
+        $exif->method('readMetadata')->willReturn(['rating' => 0, 'label' => 'Red', 'pick' => 'none']);
+        $exif->expects($this->once())
+            ->method('writeMetadata')
+            ->with($this->isInstanceOf(File::class), null, '', null, 'en');
+
+        $tag = $this->createMock(TagService::class);
+        $tag->expects($this->once())
+            ->method('setMetadata')
+            ->with('42', ['color' => null]);
+
+        $service = $this->makeHealService(
+            $this->healConfig([['file_id' => 42, 'rating' => null, 'color' => '', 'pick' => null, 'timestamp' => 100]]),
+            $this->rootFolderReturning($this->healFile(50)),
+            $exif,
+            $this->settingsMock(true, 'en'),
+            $tag,
+        );
+
+        $report = $service->healGuestXmp(self::OWNER_ID, true);
+
+        $this->assertSame(1, $report['stats']['healed']);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $logEntries
+     * @return array<string, string>  configkey => stored JSON
+     */
+    private function healConfig(array $logEntries, string $token = 'TOK'): array
+    {
+        return [
+            'starrate_shares'                => json_encode([$token => ['token' => $token, 'owner_id' => self::OWNER_ID]]),
+            "starrate_guest_log_{$token}"    => json_encode($logEntries),
+        ];
+    }
+
+    private function healFile(int $mtime, string $mime = 'image/jpeg'): File
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getMimeType')->willReturn($mime);
+        $file->method('getMTime')->willReturn($mtime);
+        $file->method('getName')->willReturn('photo.jpg');
+        return $file;
+    }
+
+    /**
+     * @param array<string, string> $configMap configkey => stored value
+     */
+    private function makeHealService(
+        array $configMap,
+        IRootFolder $rootFolder,
+        ExifService $exif,
+        UserSettings $userSettings,
+        ?TagService $tag = null,
+    ): ShareService {
+        $config = $this->createMock(IConfig::class);
+        $config->method('getUserValue')->willReturnCallback(
+            static fn(string $uid, string $app, string $key, $default = '') => $configMap[$key] ?? $default
+        );
+
+        return new ShareService(
+            $config,
+            $rootFolder,
+            $this->createMock(IPreviewManager::class),
+            $this->createMock(ISecureRandom::class),
+            $tag ?? $this->createMock(TagService::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(IDBConnection::class),
+            $exif,
+            $userSettings,
+        );
+    }
+
+    private function makeServiceForXmp(IRootFolder $rootFolder, ExifService $exif, UserSettings $userSettings): ShareService
+    {
+        $config = $this->createMock(IConfig::class);
+        $config->method('getUserValue')->willReturn('[]');
+        $config->method('setUserValue');
+
+        return new ShareService(
+            $config,
+            $rootFolder,
+            $this->createMock(IPreviewManager::class),
+            $this->createMock(ISecureRandom::class),
+            $this->createMock(TagService::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(IDBConnection::class),
+            $exif,
+            $userSettings,
+        );
     }
 
     public function testSaveGuestRatingPersistsPickField(): void


### PR DESCRIPTION
## Problem

Guest ratings made through a share link only updated the Nextcloud tag database — they were never written into the embedded JPEG XMP. Combined with the self-healing XMP read added in 1.3.3 (which treats the file's XMP as the source of truth when a JPEG is opened), a guest rating on a photo that already carried older XMP was **silently reverted** to the stale value the next time the owner opened it. The "ratings round-trip to Lightroom/digiKam via XMP" promise was therefore broken for guest input.

A second, pre-existing bug: guests could never **clear** a color label — the guest endpoint used `isset()`, which treats an explicit `null` (sent by the UI on color toggle-off) as "field absent / unchanged".

## Fix

- **`saveGuestRating` now also writes the JPEG XMP** via `ExifService`, governed by the share **owner's** `write_xmp` setting (guests have no own settings). Non-fatal: a failed XMP write still keeps the DB tag.
- **`guestRate` distinguishes clear from unchanged** — `array_key_exists` instead of `isset`, with the same `null`/`''` convention as the logged-in path. Guests can now remove a color, and the cleared state propagates to both DB and XMP.

## Migration / recovery

- **`occ starrate:heal-guest-xmp`** — recovers guest ratings made before this fix (instances on 1.3.3–1.3.5 with XMP-write on) that the self-healing read may have reverted. It reconstructs each guest's intent from the per-share guest log (not the possibly-already-reverted DB) and writes it back to DB + XMP. **Conflict-safe**: a file edited externally (Lightroom/digiKam) *after* the guest rated — detected via file mtime vs. guest-log timestamp — is left untouched. Defaults to dry-run; `--write` applies, `--user` scopes to one owner.
- **`GuestXmpDriftWarning`** repair step — on app upgrade, scans the guest logs read-only (no file I/O) and reports how many guest-rated files may need healing, pointing to the command. Writes nothing.

## Testing

- 299 PHPUnit tests green (+12 new in `ShareServiceTest`: forward-write, fold/global-order, mtime guard, in-sync skip, write_xmp-off skip, color/pick clear).
- Multi-agent code review run; findings fixed (cross-token global fold, `--user` empty-guard, pick normalization, info.xml `<repair-steps>` ordering, phantom-entry filter).
- Dry-run + `--write` exercised on production: 290 legacy guest ratings healed, 0 errors, idempotent on re-run; 89 conflict-safe skips.

Version bump and changelog are handled separately on the release branch.
