### PR TITLE
fix: guest color-clear response returns null + ignore NC-core E2E exception

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -15,7 +15,7 @@ module.exports = {
       'tests/e2e/mobile-virtualization.cy.js',
       'tests/e2e/api-security.cy.js',
     ],
-    supportFile:        false,
+    supportFile:        'tests/e2e/support.js',
     screenshotsFolder:  'tests/results/cypress/screenshots',
     videosFolder:       'tests/results/cypress/videos',
     downloadsFolder:    'tests/results/cypress/downloads',

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -451,6 +451,10 @@ class ShareService
             "StarRate: Gast '{$entry['guest_name']}' hat Datei {$fileId} gesetzt: {$action} (Share {$token})."
         );
 
+        // API-Antwort spiegelt den effektiven Wert: '' (internes Lösch-Sentinel) → null.
+        // Der Log-Eintrag oben behält '' für die Heal-Unterscheidung (clear vs. unverändert).
+        $entry['color'] = $color === '' ? null : $color;
+
         return $entry;
     }
 

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -638,10 +638,13 @@ class ShareServiceTest extends TestCase
             $tag,
         );
 
-        $service->saveGuestRating(
+        $result = $service->saveGuestRating(
             ['token' => self::SAMPLE_TOKEN, 'owner_id' => self::OWNER_ID],
             42, null, '', null, 'Anna'
         );
+
+        // API-Antwort liefert den effektiven Wert (null), nicht das interne '' -Sentinel.
+        $this->assertNull($result['color']);
     }
 
     public function testHealGuestXmpClearsColorViaEmptyString(): void

--- a/tests/e2e/support.js
+++ b/tests/e2e/support.js
@@ -1,0 +1,14 @@
+// Cypress Support-File (global für alle E2E-Specs).
+//
+// Nextclouds Core-JS (core-unsupported-browser-redirect.js → Browser-Support-Check)
+// wirft unter Cypress' Electron-User-Agent eine "Cannot read properties of undefined
+// (reading 'from')"-Exception. Das ist ein NC-Core-×-Testbrowser-Problem, KEIN
+// StarRate-Fehler (die App rendert normal). Cypress failt aber per Default jeden Test
+// bei jeder uncaught Exception — deshalb hier gezielt nur diese eine ignorieren.
+// Alle anderen App-Fehler failen den Test weiterhin.
+Cypress.on('uncaught:exception', (err) => {
+  if (err && err.message && err.message.includes("reading 'from'")) {
+    return false
+  }
+  return undefined
+})


### PR DESCRIPTION
Follow-ups found while validating 1.3.6 via the Cypress E2E suite.

## Guest color-clear response (app fix)
A guest clearing a color (`color: null`) was correctly stored as null in the DB, but `saveGuestRating` echoed the internal `''` clear-sentinel back in the API response. Now the response reflects the effective value (`null`); the guest-log entry keeps `''` so the heal command can still tell *clear* from *unchanged*. (The Vue frontend updates optimistically and ignores the response, so users were never affected — but the API/E2E contract is now correct.) Caught by `guest-gallery.cy.js:332`.

## E2E: ignore NC-core browser-check exception (test-only)
26 logged-in specs were failing on `Uncaught TypeError: Cannot read properties of undefined (reading 'from')` — traced to **Nextcloud core** JS (`core-unsupported-browser-redirect.js`), which throws under Cypress's Electron user-agent. Not a StarRate error (the app renders fine). Added a support file that ignores *only* that specific exception so it no longer fails unrelated specs; real app errors still fail.

## Result
Full E2E suite now **75/75 green** against NC 33 (was 49/75). PHPUnit 299 + the new color-clear response assertion green.

Test-only changes are not shipped in the release tarball.