### PR TITLE
Fix recursive view in group folders and shares

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,7 +66,7 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 - Englisch und Deutsch
     ]]></description>
 
-    <version>1.3.4</version>
+    <version>1.3.7</version>
     <licence>agpl</licence>
 
     <author mail="starrate@merlin1.de" homepage="https://github.com/merlin1de/starrate">

--- a/docs/recursive-folders.de.md
+++ b/docs/recursive-folders.de.md
@@ -62,6 +62,15 @@ Gut zu wissen:
 - Tiefe = 0 ist meist die richtige Wahl bei chronologischer Sortierung („alles vom Wochenende, egal aus welchem Ordner").
 - Tiefe ≥ 1 hilft, wenn du beim Scrollen in den Ordner-Kontext zurückfinden willst (Vorbereitung vor Trauung vor Empfang).
 
+## Welche Speicher erfasst werden
+
+Die rekursive Ansicht durchläuft alles, was im **selben Speicher** liegt wie der geöffnete Ordner. In der Praxis deckt das die relevanten Fälle ab:
+
+- **Eigene Dateien** (Home-Storage) — vollständig.
+- **Group Folders** und **geteilte Ordner** — vollständig. Teilt ein Admin dir einen Group Folder, zeigt das rekursive Öffnen jedes Bild darunter.
+
+**Nicht erfasst:** ein **External-Storage**-Mount oder ein anderer Mount, der *innerhalb* des geöffneten Ordners eingehängt ist. Diese liegen in einem eigenen Speicher mit eigenem Index, und StarRate folgt dieser Grenze bewusst nicht — sonst würde die Ansicht langsam, nicht-deterministisch und davon abhängig, ob der External Storage gerade vollständig indiziert ist. Wenn du Dateien auf einem External Storage cullen willst, öffne dessen Ordner direkt und nutze die rekursive Ansicht von dort.
+
 ## Folder-Cache
 
 Pro Ordner merkt sich StarRate im Browser-`localStorage`, ob du ihn rekursiv geöffnet hast und mit welcher Tiefe.

--- a/docs/recursive-folders.en.md
+++ b/docs/recursive-folders.en.md
@@ -62,6 +62,15 @@ Good to know:
 - Depth = 0 is usually the right pick for chronological sorting ("everything from this weekend, no matter which folder").
 - Depth ≥ 1 helps when you want to keep folder context as you scroll (Preparation before Ceremony before Reception).
 
+## Which storages are covered
+
+Recursive view walks everything that lives in the **same storage** as the folder you opened. In practice that covers the cases that matter:
+
+- **Your own files** (home storage) — fully.
+- **Group folders** and **shared folders** — fully. If an admin shares a group folder with you, opening it recursively shows every image beneath it.
+
+**Not covered:** an **External Storage** mount, or another mount nested *inside* the folder you opened. Those live in a separate storage with its own index, and StarRate deliberately does not follow across that boundary — doing so would make the view slow, non-deterministic and dependent on whether the external storage happens to be fully indexed. If you need to cull files on an external storage, open that storage's folder directly and use recursive view from there.
+
 ## Folder cache
 
 StarRate remembers per folder, in your browser's `localStorage`, whether you opened it recursively and at which depth.

--- a/lib/Controller/GalleryController.php
+++ b/lib/Controller/GalleryController.php
@@ -379,9 +379,23 @@ class GalleryController extends Controller
      */
     private function listImagesRecursiveFromDb(Folder $folder, string $userBase, int $depth): array
     {
-        $storageId    = $folder->getStorage()->getCache()->getNumericStorageId();
-        $internalPath = $folder->getInternalPath();
-        $pathPrefix   = ($internalPath === '' ? '' : $internalPath . '/') . '%';
+        // Echte (storage, internalPath) des Recursion-Roots direkt aus dem
+        // Filecache holen — NICHT aus der gewrappten Node-Sicht. Bei Group
+        // Folders / Shares liefert getInternalPath() einen jail-relativen,
+        // gekürzten Pfad (z.B. 'Bench' statt 'files/Bench'), der nicht zu den
+        // roh in oc_filecache gespeicherten Pfaden passt → sonst 0 Treffer.
+        // Der fileid-Lookup gibt die echte, jail-/mount-unabhängige Koordinate.
+        $real = $this->resolveCacheLocation($folder->getId());
+        if ($real === null) {
+            return [];
+        }
+        [$storageId, $rootInternalPath] = $real;
+        // LIKE-Metazeichen (% und _) im Ordnerpfad escapen, damit ein Ordner
+        // wie 'My_Folder' nicht versehentlich Geschwister wie 'MyXFolder'
+        // mitmatcht. Der angehängte '/%'-Wildcard bleibt bewusst unescaped.
+        $pathPrefix = ($rootInternalPath === ''
+            ? ''
+            : $this->db->escapeLikeParameter($rootInternalPath) . '/') . '%';
 
         $qb = $this->db->getQueryBuilder();
         $qb->select('fc.fileid', 'fc.name', 'fc.path', 'fc.size', 'fc.mtime', 'mt.mimetype')
@@ -401,31 +415,65 @@ class GalleryController extends Controller
         $rows = $result->fetchAll();
         $result->closeCursor();
 
-        // userBase + 'files' als Trim-Basis: oc_filecache.path startet mit
-        // 'files/...' für die Home-Storage; absoluter Display-Pfad braucht das
-        // userBase-Präfix. relPath wird relativ zum Recursion-Root gebildet.
-        $rootInternalPrefix = $internalPath === '' ? 'files' : $internalPath;
+        // Anzeige-Pfade aus dem User-Pfad des Recursion-Roots + relativem Rest
+        // bauen — NICHT hart 'files/' strippen. $folder->getPath() enthält den
+        // vollen, mount-korrekten User-Pfad inkl. evtl. Group-Folder-Mountpunkt
+        // (z.B. '/BenchGF/Bench'); würde man stattdessen den rohen Storage-Pfad
+        // ('files/Bench/...') ab 'files/' kürzen, ginge das Mount-Präfix
+        // verloren und die Bilder wären nicht mehr auffindbar.
+        $rootUserPath = rtrim(substr($folder->getPath(), strlen($userBase)), '/');
+        $rootLen = strlen($rootInternalPath);
 
         $images = [];
         foreach ($rows as $row) {
-            $internalRelative = ltrim(substr($row['path'], strlen($rootInternalPrefix)), '/');
+            // Pfad relativ zum Recursion-Root, ohne führenden Slash.
+            $relPath = ltrim(substr($row['path'], $rootLen), '/');
 
             $images[] = [
                 'id'       => (int) $row['fileid'],
                 'name'     => $row['name'],
                 // User-folder-relativer Pfad mit führendem Slash, wie
                 // buildImageEntry(): '/Photos/IMG.jpg' statt absolut.
-                'path'     => '/' . substr($row['path'], strlen('files/')),
-                'relPath'  => $internalRelative,
+                'path'     => $rootUserPath . '/' . $relPath,
+                'relPath'  => $relPath,
                 'size'     => (int) $row['size'],
                 'mtime'    => (int) $row['mtime'],
                 'mimetype' => $row['mimetype'],
-                'groupKey' => $depth > 0 ? self::pathPrefix($internalRelative, $depth) : '',
+                'groupKey' => $depth > 0 ? self::pathPrefix($relPath, $depth) : '',
                 'width'    => null,
                 'height'   => null,
             ];
         }
         return $images;
+    }
+
+    /**
+     * Liefert die echte (numeric storage id, storage-interner Pfad) eines
+     * Knotens anhand seiner fileid — direkt aus oc_filecache, unabhängig von
+     * Jail-/Mount-Wrappern. Group Folders und Shares zeigen über
+     * getInternalPath() eine gejailte, gekürzte Pfad-Sicht, die nicht zu den
+     * roh gespeicherten Filecache-Pfaden passt; der fileid-Lookup umgeht das.
+     *
+     * Bewusst NUR dieser eine Storage: verschachtelte Fremd-Mounts (External
+     * Storage etc.) unterhalb des Ordners werden nicht verfolgt — siehe
+     * docs/recursive-folders.*.md (Limitations). Das hält die Suche auf einem
+     * einzigen indizierten Range-Scan und damit deterministisch und schnell.
+     *
+     * @return array{0: int, 1: string}|null [storageId, internalPath] oder null
+     */
+    private function resolveCacheLocation(int $fileId): ?array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('storage', 'path')
+            ->from('filecache')
+            ->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)));
+        $result = $qb->executeQuery();
+        $row = $result->fetch();
+        $result->closeCursor();
+        if ($row === false) {
+            return null;
+        }
+        return [(int) $row['storage'], (string) $row['path']];
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starrate",
-  "version": "1.2.11",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starrate",
-      "version": "1.2.11",
+      "version": "1.3.7",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/event-bus": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrate",
-  "version": "1.3.4",
+  "version": "1.3.7",
   "type": "module",
   "description": "Professionelles Foto-Bewertungs- und Lightroom-Sync-Tool für Nextcloud",
   "scripts": {

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -67,7 +67,7 @@
 
           <span class="sr-breadcrumb__version">
             StarRate v{{ appVersion }}<br/>
-            by <a href="https://www.instagram.com/merlin1.de/" target="_blank" rel="noopener noreferrer" class="sr-breadcrumb__version-link">Merlin1.De</a>
+            by <a href="https://whitespace.de" target="_blank" rel="noopener noreferrer" class="sr-breadcrumb__version-link">Whitespace</a>
           </span>
         </div>
       </div>

--- a/src/views/GuestGallery.vue
+++ b/src/views/GuestGallery.vue
@@ -6,7 +6,7 @@
       <!-- Branding -->
       <div class="sr-guest-pw__brand">
         <div class="sr-guest-pw__brand-name">StarRate <span class="sr-guest-pw__brand-version">v{{ appVersion }}</span></div>
-        <div class="sr-guest-pw__brand-by">by <a href="https://www.instagram.com/merlin1.de/" target="_blank" rel="noopener noreferrer" class="sr-guest-pw__brand-link">Merlin1.De</a></div>
+        <div class="sr-guest-pw__brand-by">by <a href="https://whitespace.de" target="_blank" rel="noopener noreferrer" class="sr-guest-pw__brand-link">Whitespace</a></div>
       </div>
 
       <h2 class="sr-guest-pw__title">{{ t('starrate', 'Passwortgeschützte Galerie') }}</h2>


### PR DESCRIPTION
## Problem

Recursive view returned **no images at all** when the browsed folder lives in a **group folder** (or a share) — reported in #80. The non-recursive view worked fine in the very same folder.

## Root cause

`listImagesRecursiveFromDb()` is the only image-listing path that bypasses Nextcloud's storage abstraction and queries `oc_filecache` directly (a deliberate memory optimization for large trees). It derived the query coordinates from the *wrapped* node view:

- `getStorage()->getCache()->getNumericStorageId()` — correct
- `getInternalPath()` — for a jailed storage (group folder / share) this returns a **jail-relative** path (e.g. `Bench`) that does **not** match the raw filecache paths (`files/Bench/...`)

So `WHERE storage = X AND path LIKE 'Bench/%'` matched nothing → empty gallery. The non-recursive path was never affected because it uses `getDirectoryListing()`, which resolves jails/mounts correctly.

## Fix

- New `resolveCacheLocation(fileId)` reads the **real** `(storage, path)` straight from `oc_filecache` by fileid — jail-/mount-independent. One extra primary-key lookup, negligible cost.
- Display paths are built from the recursion root's user-facing path (`$folder->getPath()`) + the relative remainder, instead of hard-stripping `files/`. This preserves the mount prefix (e.g. the group-folder name) and fixes a second latent bug where recursive display paths dropped it.
- The `LIKE` prefix is escaped via `escapeLikeParameter()` so `%` / `_` in folder names cannot act as wildcards.

## Deliberate scope

Recursive view covers everything in the **same storage** as the opened folder — home, group folders, shares. **External Storage and nested foreign mounts are intentionally not followed** (single-storage by design: keeps the query a single indexed range scan — deterministic and fast). Documented in `docs/recursive-folders.{en,de}.md`.

## Verified

Measured on Nextcloud 33 with a 5000-image tree:

| | Home | Group folder |
|---|---|---|
| before | 5000 | **0** |
| after | 5000 | **5000** |

Same cost as the home-storage path (~3.4 ms, ~28 MB peak). Escape regression test: a `My_Folder` next to a `MyXFolder` correctly returns only `My_Folder`'s images (3, not 8). All 299 PHPUnit tests pass.

## Also in this PR

- Credit link in the header and the guest password dialog changed to "by Whitespace" (→ https://whitespace.de).
- Version bump to 1.3.7.

Refs #80
