### PR TITLE
Loupe zoom & touch overhaul (1.3.8)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,6 +17,8 @@ Rate photos with 1–5 stars and color labels, flag picks and rejects with keybo
 
 **Built for client presentations.** Slideshow mode in the loupe auto-advances through filtered images at a configurable interval — pre-filter to your three-star picks, hand over the keyboard, and let it run.
 
+**Read the workflow guide:** [Nextcloud as a photo home — what works today (and what is still missing)](https://whitespace.de/en/artikel/nextcloud-foto-workflow/)
+
 **Features:**
 - Star ratings (0–5) + color labels (Red/Yellow/Green/Blue/Purple) + Pick/Reject flags
 - **Recursive folder view** — browse an entire folder tree as a flat stream or grouped by folder depth (1.3.0+)
@@ -47,6 +49,8 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 
 **Gemacht für Kundenpräsentationen.** Diashow-Modus in der Loupe läuft mit einstellbarem Intervall automatisch durch die gefilterten Bilder — auf Drei-Sterne-Picks vorfiltern, Tastatur übergeben, laufen lassen.
 
+**Zum Workflow-Guide:** [Nextcloud als Foto-Heimat — was geht heute (und was noch fehlt)](https://whitespace.de/de/artikel/nextcloud-foto-workflow/)
+
 **Features:**
 - Sternbewertungen (0–5) + Farb-Labels (Rot/Gelb/Grün/Blau/Lila) + Pick/Reject-Flags
 - **Rekursive Ordneransicht** — kompletten Ordnerbaum als flachen Stream oder nach Ordnertiefe gruppiert durchblättern (ab 1.3.0)
@@ -66,7 +70,7 @@ Bilder mit 1–5 Sternen und Farb-Labels bewerten, Picks und Rejects per Tastatu
 - Englisch und Deutsch
     ]]></description>
 
-    <version>1.3.7</version>
+    <version>1.3.8</version>
     <licence>agpl</licence>
 
     <author mail="starrate@merlin1.de" homepage="https://github.com/merlin1de/starrate">

--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -13,6 +13,7 @@ module.exports = {
       'tests/e2e/pick-reject.cy.js',
       'tests/e2e/comments.cy.js',
       'tests/e2e/mobile-virtualization.cy.js',
+      'tests/e2e/download.cy.js',
       'tests/e2e/api-security.cy.js',
     ],
     supportFile:        'tests/e2e/support.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starrate",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starrate",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/event-bus": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrate",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "description": "Professionelles Foto-Bewertungs- und Lightroom-Sync-Tool für Nextcloud",
   "scripts": {

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -356,7 +356,6 @@ const showControls   = ref(true)
 let   hideControlsTimer = null
 
 // Zoom + Pan
-const MIN_ZOOM    = 0.25
 const MAX_ZOOM    = 4.0
 // Doppelklick-Over-Zoom: fester Faktor relativ zum Fit. Formatunabhängig (Hoch/Quer
 // gleich) und auf jedem Display gleich (FHD/Tablet/4K), weil relativ zur Fit-Größe.
@@ -536,8 +535,15 @@ function preloadAdjacent(idx) {
 // ─── Zoom ─────────────────────────────────────────────────────────────────────
 
 function setZoom(newZoom, pivot = null) {
-  newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom))
-  isFit.value  = false
+  newZoom = Math.min(MAX_ZOOM, newZoom)
+  // Fit (zoom = 1.0) ist die Untergrenze: kleiner als eingepasst gibt es nicht.
+  // Jedes Rauszoomen, das darunter ginge, schnappt auf Fit — zentral für Wheel,
+  // Tastatur und Pinch, damit Rein-/Rauszoomen symmetrisch an derselben Grenze endet.
+  if (newZoom <= 1.0) {
+    resetZoom()
+    return
+  }
+  isFit.value = false
 
   if (pivot && loupeEl.value) {
     // Zoom auf die Pivot-Position: der Punkt unter dem Cursor bleibt fix.
@@ -597,17 +603,9 @@ function constrainPan() {
 // ─── Events: Maus ────────────────────────────────────────────────────────────
 
 function onWheel(e) {
-  // Im Fit-Modus: nur Reinzoomen erlaubt, Rauszoomen ignorieren
-  if (isFit.value && e.deltaY > 0) return
-
-  const delta   = e.deltaY > 0 ? 0.85 : 1 / 0.85
-  const newZoom = zoom.value * delta
-
-  // Bei MIN_ZOOM angekommen → nicht weiter rauszoomen
-  if (newZoom <= MIN_ZOOM && e.deltaY > 0) return
-
-  isFit.value = false
-  setZoom(newZoom, { x: e.clientX, y: e.clientY })
+  // Floor (Fit) und Ceiling (MAX_ZOOM) regelt setZoom zentral.
+  const delta = e.deltaY > 0 ? 0.85 : 1 / 0.85
+  setZoom(zoom.value * delta, { x: e.clientX, y: e.clientY })
 }
 
 function onDblClick(e) {
@@ -781,15 +779,12 @@ function onKeydown(e) {
     case '+':
     case '=':
       e.preventDefault()
-      isFit.value = false
       setZoom(zoom.value * 1.25)
       break
     case '-':
     case '_':
       e.preventDefault()
-      if (isFit.value) break
-      if (zoom.value * 0.8 <= MIN_ZOOM) break
-      setZoom(zoom.value * 0.8)
+      setZoom(zoom.value * 0.8)   // floort zentral auf Fit
       break
     case ' ':
       e.preventDefault()

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -368,7 +368,10 @@ const panStart  = ref({ x: 0, y: 0, panX: 0, panY: 0 })
 // Touch-Pinch
 const touches = ref([])
 let   lastPinchDist = 0
-let   touchStartedAsSingle = false
+// Gesten-Modus: einmal festgelegt, gilt für die ganze Geste (bis alle Finger weg).
+// 'pinch' sobald je 2 Finger unten waren — kein Zurückwechseln, damit ein kurz
+// vorausgewanderter Finger den Zoom nicht abwürgt (war der alte 30px-Abbruch-Bug).
+let   gestureMode = 'none'   // 'none' | 'single' | 'pinch'
 let   swipeOrigin = null
 let   lastTouchEnd = 0
 
@@ -546,6 +549,7 @@ function setZoom(newZoom, pivot = null) {
 
   zoom.value = newZoom
   constrainPan()
+  resetControlsTimer()   // jeder Zoom-Wechsel (Wheel, Pinch, Tastatur) armiert frisch
 }
 
 function resetZoom() {
@@ -553,8 +557,7 @@ function resetZoom() {
   zoom.value  = 1.0
   panX.value  = 0
   panY.value  = 0
-  showControls.value = true
-  clearTimeout(hideControlsTimer)
+  resetControlsTimer()   // Fit → sichtbar, kein Hide-Timer (siehe resetControlsTimer)
 }
 
 function zoomTo100() {
@@ -562,6 +565,7 @@ function zoomTo100() {
   zoom.value  = 1.0   // Pixel-für-Pixel
   panX.value  = 0
   panY.value  = 0
+  resetControlsTimer()   // zoomed-in → Hide-Timer armieren
 
   // Tatsächliche Pixel-Zoom: Bild-Originalbreite / Containerbreite
   nextTick(() => {
@@ -648,24 +652,17 @@ function onMouseUp() {
 
 function onTouchStart(e) {
   touches.value = Array.from(e.touches)
+  resetControlsTimer()   // jede Berührung holt die Leiste zurück (Touch-Parität zur Maus)
 
-  if (touches.value.length === 2) {
-    // Allow pinch if gesture started with 2 fingers OR if the first finger
-    // hasn't moved much (user is stationary, intentionally adding 2nd finger).
-    // Block only when mid-swipe (first finger already moved significantly).
-    if (touchStartedAsSingle && swipeOrigin) {
-      const dx = touches.value[0].clientX - swipeOrigin.x
-      const dy = touches.value[0].clientY - swipeOrigin.y
-      if (Math.sqrt(dx * dx + dy * dy) > 30) {
-        // Mid-swipe — ignore accidental second finger
-        return
-      }
-      // Finger was stationary — allow intentional pinch
-      touchStartedAsSingle = false
-    }
-    lastPinchDist = getPinchDist(touches.value)
-  } else if (touches.value.length === 1) {
-    touchStartedAsSingle = true
+  if (touches.value.length >= 2) {
+    // Zwei Finger unten → für den Rest der Geste Pinch-Modus. Kein Distanz-Check:
+    // wer einen zweiten Finger aufsetzt, will zoomen. Ein versehentlicher Zoom ist
+    // jederzeit zurückzoombar — das ist robuster als die alte Abbruch-Heuristik.
+    gestureMode    = 'pinch'
+    isPanning.value = false
+    lastPinchDist  = getPinchDist(touches.value)
+  } else if (touches.value.length === 1 && gestureMode !== 'pinch') {
+    gestureMode = 'single'
     swipeOrigin = { x: touches.value[0].clientX, y: touches.value[0].clientY }
     if (!isFit.value) {
       isPanning.value = true
@@ -682,19 +679,21 @@ function onTouchStart(e) {
 function onTouchMove(e) {
   const currentTouches = Array.from(e.touches)
 
-  if (currentTouches.length === 2 && !touchStartedAsSingle) {
-    // Pinch-to-Zoom — only when gesture started with 2 fingers
+  if (gestureMode === 'pinch' && currentTouches.length >= 2) {
+    // Pinch-to-Zoom — auf den Finger-Mittelpunkt als Pivot, damit das Bild dort
+    // wächst, wo die Finger sind (nicht um die Bildmitte).
     isPanning.value = false
     const dist  = getPinchDist(currentTouches)
     const ratio = dist / lastPinchDist
-    if (Math.abs(ratio - 1) > 0.03) {
-      setZoom(zoom.value * ratio)
+    if (Math.abs(ratio - 1) > 0.01) {
+      setZoom(zoom.value * ratio, pinchMidpoint(currentTouches))
+      lastPinchDist = dist
     }
-    lastPinchDist = dist
-  } else if (currentTouches.length === 1 && isPanning.value) {
+  } else if (gestureMode === 'single' && currentTouches.length === 1 && isPanning.value) {
     panX.value = panStart.value.panX + (currentTouches[0].clientX - panStart.value.x)
     panY.value = panStart.value.panY + (currentTouches[0].clientY - panStart.value.y)
     constrainPan()
+    resetControlsTimer()   // Pan hält die Leiste sichtbar und re-armt den Hide-Timer
   }
 }
 
@@ -702,23 +701,23 @@ function onTouchEnd(e) {
   const remaining = Array.from(e.touches)
 
   if (remaining.length === 0) {
-    // Alle Finger weg — Swipe-Erkennung + State-Reset
-    if (touchStartedAsSingle && isFit.value && touches.value.length >= 1) {
-      const t0  = touches.value[0]
+    // Alle Finger weg — Swipe nur werten, wenn die Geste durchgehend Ein-Finger war.
+    if (gestureMode === 'single' && isFit.value && swipeOrigin) {
       const t1  = e.changedTouches[0]
-      const dx  = t1.clientX - t0.clientX
-      const dy  = Math.abs(t1.clientY - t0.clientY)
+      const dx  = t1.clientX - swipeOrigin.x
+      const dy  = Math.abs(t1.clientY - swipeOrigin.y)
 
       if (Math.abs(dx) > 60 && dy < 80) {
         navigate(dx < 0 ? 1 : -1)
       }
     }
     isPanning.value = false
-    touchStartedAsSingle = false
-    swipeOrigin = null
-    lastTouchEnd = Date.now()
-  } else if (remaining.length === 1) {
-    // Ein Finger übrig nach Pinch — kein Swipe-Reset, nur Panning stoppen
+    gestureMode     = 'none'
+    swipeOrigin     = null
+    lastTouchEnd    = Date.now()
+  } else {
+    // Noch Finger übrig (z.B. ein Finger nach Pinch) — Pinch-Modus bleibt bis 0,
+    // damit kein Swipe/Pan dazwischenfunkt. Nur Panning stoppen.
     isPanning.value = false
   }
 
@@ -729,6 +728,13 @@ function getPinchDist(ts) {
   const dx = ts[0].clientX - ts[1].clientX
   const dy = ts[0].clientY - ts[1].clientY
   return Math.sqrt(dx * dx + dy * dy)
+}
+
+function pinchMidpoint(ts) {
+  return {
+    x: (ts[0].clientX + ts[1].clientX) / 2,
+    y: (ts[0].clientY + ts[1].clientY) / 2,
+  }
 }
 
 // ─── Tastatur ────────────────────────────────────────────────────────────────
@@ -847,8 +853,13 @@ function onKeydown(e) {
 function resetControlsTimer() {
   showControls.value = true
   clearTimeout(hideControlsTimer)
+  // Im Fit-Modus bleibt die Leiste immer sichtbar — gar kein Hide-Timer.
+  // Nur wenn reingezoomt ist, nach 3s ausblenden (Bild nicht verdecken).
+  // Wird aus jedem Zoom-Wechsel und jeder Touch-Interaktion neu armiert, daher
+  // ist die Sichtbarkeit eine reine Funktion des Zustands — kein One-Shot-Race.
+  if (isFit.value) return
   hideControlsTimer = setTimeout(() => {
-    if (isPanning.value || isFit.value) return  // im Fit-Modus immer sichtbar
+    if (isPanning.value) return  // mitten im Pan: sichtbar lassen, re-armt beim nächsten Move
     showControls.value = false
   }, 3000)
 }

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -369,7 +369,6 @@ const isPanning = ref(false)
 const panStart  = ref({ x: 0, y: 0, panX: 0, panY: 0 })
 
 // Touch-Pinch
-const touches = ref([])
 let   lastPinchDist = 0
 // Gesten-Modus: einmal festgelegt, gilt für die ganze Geste (bis alle Finger weg).
 // 'pinch' sobald je 2 Finger unten waren — kein Zurückwechseln, damit ein kurz
@@ -546,11 +545,9 @@ function setZoom(newZoom, pivot = null) {
   isFit.value = false
 
   if (pivot && loupeEl.value) {
-    // Zoom auf die Pivot-Position: der Punkt unter dem Cursor bleibt fix.
-    // Das Transform ist translate(pan) ∘ scale(zoom) um die Container-Mitte,
-    // also rein im Screen-Space — die Formel braucht KEINE echten Bildmaße.
-    // d = Cursor relativ zur Container-Mitte. Festpunkt-Bedingung d = pan + z·q
-    // (q = Bildpunkt) führt auf: pan' = d − ratio·(d − pan).
+    // Punkt unter dem Cursor bleibt fix. Reine Screen-Space-Geometrie (Transform =
+    // translate(pan) ∘ scale um die Container-Mitte), daher ohne echte Bildmaße:
+    // pan' = d − ratio·(d − pan), mit d = Cursor relativ zur Container-Mitte.
     const rect    = loupeEl.value.getBoundingClientRect()
     const dx      = pivot.x - rect.left - rect.width  / 2
     const dy      = pivot.y - rect.top  - rect.height / 2
@@ -623,21 +620,15 @@ function onDblClick(e) {
 
 function onMouseDown(e) {
   if (e.button !== 0) return
-  if (isFit.value && zoom.value <= 1.0) return
+  if (isFit.value) return   // im Fit (= Zoom-Untergrenze) gibt es nichts zu pannen
 
-  isPanning.value = true
-  panStart.value  = { x: e.clientX, y: e.clientY, panX: panX.value, panY: panY.value }
+  startPan(e.clientX, e.clientY)
   e.preventDefault()
 }
 
 function onMouseMove(e) {
   if (!isPanning.value) return
-  panX.value = panStart.value.panX + (e.clientX - panStart.value.x)
-  panY.value = panStart.value.panY + (e.clientY - panStart.value.y)
-  constrainPan()
-
-  // Steuerelemente ausblenden beim Panning
-  resetControlsTimer()
+  panTo(e.clientX, e.clientY)
 }
 
 function onMouseUp() {
@@ -646,29 +637,34 @@ function onMouseUp() {
 
 // ─── Events: Touch (Swipe + Pinch) ───────────────────────────────────────────
 
+function startPan(clientX, clientY) {
+  isPanning.value = true
+  panStart.value  = { x: clientX, y: clientY, panX: panX.value, panY: panY.value }
+}
+
+// Pan-Schritt — von Maus (onMouseMove) und Ein-Finger-Touch (onTouchMove) geteilt.
+function panTo(clientX, clientY) {
+  panX.value = panStart.value.panX + (clientX - panStart.value.x)
+  panY.value = panStart.value.panY + (clientY - panStart.value.y)
+  constrainPan()
+  resetControlsTimer()   // Pan hält die Leiste sichtbar und re-armt den Hide-Timer
+}
+
 function onTouchStart(e) {
-  touches.value = Array.from(e.touches)
+  const cur = Array.from(e.touches)
   resetControlsTimer()   // jede Berührung holt die Leiste zurück (Touch-Parität zur Maus)
 
-  if (touches.value.length >= 2) {
+  if (cur.length >= 2) {
     // Zwei Finger unten → für den Rest der Geste Pinch-Modus. Kein Distanz-Check:
     // wer einen zweiten Finger aufsetzt, will zoomen. Ein versehentlicher Zoom ist
     // jederzeit zurückzoombar — das ist robuster als die alte Abbruch-Heuristik.
     gestureMode    = 'pinch'
     isPanning.value = false
-    lastPinchDist  = getPinchDist(touches.value)
-  } else if (touches.value.length === 1 && gestureMode !== 'pinch') {
+    lastPinchDist  = getPinchDist(cur)
+  } else if (cur.length === 1 && gestureMode !== 'pinch') {
     gestureMode = 'single'
-    swipeOrigin = { x: touches.value[0].clientX, y: touches.value[0].clientY }
-    if (!isFit.value) {
-      isPanning.value = true
-      panStart.value  = {
-        x: touches.value[0].clientX,
-        y: touches.value[0].clientY,
-        panX: panX.value,
-        panY: panY.value,
-      }
-    }
+    swipeOrigin = { x: cur[0].clientX, y: cur[0].clientY }
+    if (!isFit.value) startPan(cur[0].clientX, cur[0].clientY)
   }
 }
 
@@ -681,15 +677,14 @@ function onTouchMove(e) {
     isPanning.value = false
     const dist  = getPinchDist(currentTouches)
     const ratio = dist / lastPinchDist
-    if (Math.abs(ratio - 1) > 0.01) {
+    // lastPinchDist > 0 schützt vor ratio = Infinity, wenn zwei Touch-Punkte
+    // beim Start zusammenfallen (Handballen, grober Digitizer) → kein Sprung auf MAX.
+    if (lastPinchDist > 0 && Math.abs(ratio - 1) > 0.01) {
       setZoom(zoom.value * ratio, pinchMidpoint(currentTouches))
       lastPinchDist = dist
     }
   } else if (gestureMode === 'single' && currentTouches.length === 1 && isPanning.value) {
-    panX.value = panStart.value.panX + (currentTouches[0].clientX - panStart.value.x)
-    panY.value = panStart.value.panY + (currentTouches[0].clientY - panStart.value.y)
-    constrainPan()
-    resetControlsTimer()   // Pan hält die Leiste sichtbar und re-armt den Hide-Timer
+    panTo(currentTouches[0].clientX, currentTouches[0].clientY)
   }
 }
 
@@ -711,13 +706,16 @@ function onTouchEnd(e) {
     gestureMode     = 'none'
     swipeOrigin     = null
     lastTouchEnd    = Date.now()
+  } else if (remaining.length === 1 && !isFit.value) {
+    // Pinch endet, ein Finger bleibt → in Ein-Finger-Pan übergehen, damit
+    // "pinch, dann mit einem Finger ziehen" funktioniert. panStart fängt die
+    // aktuelle Fingerposition, daher kein Sprung. Kein Swipe (nicht im Fit).
+    gestureMode = 'single'
+    swipeOrigin = { x: remaining[0].clientX, y: remaining[0].clientY }
+    startPan(remaining[0].clientX, remaining[0].clientY)
   } else {
-    // Noch Finger übrig (z.B. ein Finger nach Pinch) — Pinch-Modus bleibt bis 0,
-    // damit kein Swipe/Pan dazwischenfunkt. Nur Panning stoppen.
     isPanning.value = false
   }
-
-  touches.value = remaining
 }
 
 function getPinchDist(ts) {

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -374,8 +374,17 @@ let   lastPinchDist = 0
 // 'pinch' sobald je 2 Finger unten waren — kein Zurückwechseln, damit ein kurz
 // vorausgewanderter Finger den Zoom nicht abwürgt (war der alte 30px-Abbruch-Bug).
 let   gestureMode = 'none'   // 'none' | 'single' | 'pinch'
+let   gestureWasPinch = false  // war die Geste je ein Pinch? → kein Tap am Ende werten
 let   swipeOrigin = null
 let   lastTouchEnd = 0
+
+// Doppeltipp = zwei stehende Taps kurz hintereinander (bewegungs-gated, ortsfrei):
+// ein Swipe wandert >60px und kann so nie als Tap zählen → keine Kollision.
+const TAP_MAX_MOVE    = 10    // px — darüber ist es Swipe/Pan, kein Tap
+const DOUBLE_TAP_MS   = 300
+const DOUBLE_TAP_DIST = 40    // px Abstand der zwei Taps
+let   lastTapTime = 0
+let   lastTapPos  = { x: 0, y: 0 }
 
 // Bildübergang
 const transitionName = ref('slide-right')
@@ -659,10 +668,12 @@ function onTouchStart(e) {
     // wer einen zweiten Finger aufsetzt, will zoomen. Ein versehentlicher Zoom ist
     // jederzeit zurückzoombar — das ist robuster als die alte Abbruch-Heuristik.
     gestureMode    = 'pinch'
+    gestureWasPinch = true
     isPanning.value = false
     lastPinchDist  = getPinchDist(cur)
   } else if (cur.length === 1 && gestureMode !== 'pinch') {
     gestureMode = 'single'
+    gestureWasPinch = false
     swipeOrigin = { x: cur[0].clientX, y: cur[0].clientY }
     if (!isFit.value) startPan(cur[0].clientX, cur[0].clientY)
   }
@@ -692,13 +703,27 @@ function onTouchEnd(e) {
   const remaining = Array.from(e.touches)
 
   if (remaining.length === 0) {
-    // Alle Finger weg — Swipe nur werten, wenn die Geste durchgehend Ein-Finger war.
-    if (gestureMode === 'single' && isFit.value && swipeOrigin) {
-      const t1  = e.changedTouches[0]
-      const dx  = t1.clientX - swipeOrigin.x
-      const dy  = Math.abs(t1.clientY - swipeOrigin.y)
+    // Alle Finger weg — Geste auswerten (Tap/Doppeltipp vs. Swipe).
+    const t1 = e.changedTouches[0]
+    if (gestureMode === 'single' && swipeOrigin && t1) {
+      const dx    = t1.clientX - swipeOrigin.x
+      const dy    = t1.clientY - swipeOrigin.y
+      const moved = Math.hypot(dx, dy)
 
-      if (Math.abs(dx) > 60 && dy < 80) {
+      if (!gestureWasPinch && moved < TAP_MAX_MOVE) {
+        // Stehender Tap → Doppeltipp-Erkennung (ortsfrei, bewegungs-gated).
+        const now  = Date.now()
+        const near = Math.hypot(t1.clientX - lastTapPos.x, t1.clientY - lastTapPos.y) < DOUBLE_TAP_DIST
+        if (now - lastTapTime < DOUBLE_TAP_MS && near) {
+          // Wie Desktop-Doppelklick: Fit ⇄ Over-Zoom auf den Tipppunkt.
+          if (isFit.value) zoomToDetail({ x: t1.clientX, y: t1.clientY })
+          else resetZoom()
+          lastTapTime = 0   // verbraucht, kein Triple-Tap-Doppelauslösen
+        } else {
+          lastTapTime = now
+          lastTapPos  = { x: t1.clientX, y: t1.clientY }
+        }
+      } else if (isFit.value && Math.abs(dx) > 60 && Math.abs(dy) < 80) {
         navigate(dx < 0 ? 1 : -1)
       }
     }

--- a/src/components/LoupeView.vue
+++ b/src/components/LoupeView.vue
@@ -275,7 +275,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, watchEffect, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, watchEffect, onMounted, onUnmounted } from 'vue'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
@@ -356,9 +356,13 @@ const showControls   = ref(true)
 let   hideControlsTimer = null
 
 // Zoom + Pan
-const MIN_ZOOM  = 0.25
-const MAX_ZOOM  = 4.0
-const zoom      = ref(1.0)  // 1.0 = fit
+const MIN_ZOOM    = 0.25
+const MAX_ZOOM    = 4.0
+// Doppelklick-Over-Zoom: fester Faktor relativ zum Fit. Formatunabhängig (Hoch/Quer
+// gleich) und auf jedem Display gleich (FHD/Tablet/4K), weil relativ zur Fit-Größe.
+// Bewusst > 1 ("over zoom"): 1:1 wäre auf großen Displays oft ein Schrumpfen.
+const DETAIL_ZOOM = 3.0
+const zoom        = ref(1.0)  // 1.0 = fit
 const isFit     = ref(true)
 const panX      = ref(0)
 const panY      = ref(0)
@@ -536,15 +540,17 @@ function setZoom(newZoom, pivot = null) {
   isFit.value  = false
 
   if (pivot && loupeEl.value) {
-    // Zoom auf Mauszeiger-Position (Pivot)
+    // Zoom auf die Pivot-Position: der Punkt unter dem Cursor bleibt fix.
+    // Das Transform ist translate(pan) ∘ scale(zoom) um die Container-Mitte,
+    // also rein im Screen-Space — die Formel braucht KEINE echten Bildmaße.
+    // d = Cursor relativ zur Container-Mitte. Festpunkt-Bedingung d = pan + z·q
+    // (q = Bildpunkt) führt auf: pan' = d − ratio·(d − pan).
     const rect    = loupeEl.value.getBoundingClientRect()
-    const cx      = rect.width  / 2
-    const cy      = rect.height / 2
-    const dx      = pivot.x - rect.left - cx
-    const dy      = pivot.y - rect.top  - cy
+    const dx      = pivot.x - rect.left - rect.width  / 2
+    const dy      = pivot.y - rect.top  - rect.height / 2
     const ratio   = newZoom / zoom.value
-    panX.value    = panX.value - (dx - panX.value) * (1 - 1 / ratio)
-    panY.value    = panY.value - (dy - panY.value) * (1 - 1 / ratio)
+    panX.value    = dx - ratio * (dx - panX.value)
+    panY.value    = dy - ratio * (dy - panY.value)
   }
 
   zoom.value = newZoom
@@ -560,24 +566,10 @@ function resetZoom() {
   resetControlsTimer()   // Fit → sichtbar, kein Hide-Timer (siehe resetControlsTimer)
 }
 
-function zoomTo100() {
-  isFit.value = false
-  zoom.value  = 1.0   // Pixel-für-Pixel
-  panX.value  = 0
-  panY.value  = 0
-  resetControlsTimer()   // zoomed-in → Hide-Timer armieren
-
-  // Tatsächliche Pixel-Zoom: Bild-Originalbreite / Containerbreite
-  nextTick(() => {
-    if (imgEl.value && loupeEl.value) {
-      const nw = imgEl.value.naturalWidth
-      const cw = loupeEl.value.offsetWidth
-      if (nw > 0 && cw > 0) {
-        zoom.value = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, nw / cw))
-      }
-      // else: keep zoom = 1.0 (already set above; avoids NaN in test environments)
-    }
-  })
+function zoomToDetail(pivot = null) {
+  // Fester Over-Zoom relativ zum Fit — identisch für Hoch- und Querformat und
+  // über alle Displays. setZoom erledigt Clamp, Pivot, Pan-Constrain und Controls.
+  setZoom(DETAIL_ZOOM, pivot)
 }
 
 function constrainPan() {
@@ -585,8 +577,15 @@ function constrainPan() {
 
   const containerW = loupeEl.value.offsetWidth
   const containerH = loupeEl.value.offsetHeight
-  const imgW       = (imgEl.value.naturalWidth  || containerW) * zoom.value
-  const imgH       = (imgEl.value.naturalHeight || containerH) * zoom.value
+  const nw         = imgEl.value.naturalWidth  || containerW
+  const nh         = imgEl.value.naturalHeight || containerH
+
+  // Im Fit ist das Bild via object-fit:contain skaliert; angezeigt wird
+  // nw·fitScale × nh·fitScale. Pan-Grenzen gegen DIESE Größe rechnen (× zoom),
+  // nicht gegen die rohen Naturalmaße — sonst driftet Pan, v.a. beim Rauszoomen.
+  const fitScale = Math.min(containerW / nw, containerH / nh)
+  const imgW     = nw * fitScale * zoom.value
+  const imgH     = nh * fitScale * zoom.value
 
   const maxPanX = Math.max(0, (imgW - containerW) / 2)
   const maxPanY = Math.max(0, (imgH - containerH) / 2)
@@ -616,12 +615,11 @@ function onDblClick(e) {
   // Ignore dblclick from touch — fast swiping can trigger accidental double-taps
   if (Date.now() - lastTouchEnd < 500) return
 
+  // Toggle: Fit → Over-Zoom auf die Klickposition, sonst zurück auf Fit.
   if (isFit.value) {
-    zoomTo100()
-  } else if (zoom.value < 1.0 || Math.abs(zoom.value - 1.0) < 0.05 || zoom.value > 1.5) {
-    resetZoom()
+    zoomToDetail({ x: e.clientX, y: e.clientY })
   } else {
-    zoomTo100()
+    resetZoom()
   }
 }
 

--- a/tests/e2e/download.cy.js
+++ b/tests/e2e/download.cy.js
@@ -1,0 +1,82 @@
+/**
+ * StarRate E2E – Bild-Download (Einzel aus der Loupe + Auswahl als ZIP).
+ */
+import { login, openFolder, NC_URL, createShare, deleteShare } from './helpers'
+
+describe('Image Download', () => {
+
+  // ── Eingeloggt ──────────────────────────────────────────────────────────────
+  describe('Logged-in', () => {
+    beforeEach(() => login())
+
+    it('Loupe zeigt den Download-Button (oben rechts)', () => {
+      openFolder()
+      cy.get('.sr-grid__item').first().dblclick()
+      cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+      cy.get('.sr-loupe__download').should('be.visible')
+    })
+
+    it('Toolbar zeigt "Download (N)" nur bei Auswahl, mit korrekter Anzahl', () => {
+      openFolder()
+      // Ohne Auswahl: kein Download-Button in der Toolbar
+      cy.get('.sr-filterbar__action--download').should('not.exist')
+
+      // Zwei Bilder selektieren
+      cy.get('.sr-grid__item').eq(0).click({ ctrlKey: true })
+      cy.get('.sr-grid__item').eq(2).click({ ctrlKey: true })
+      cy.get('.sr-selbar', { timeout: 3000 }).should('be.visible')
+
+      // Toolbar-Button erscheint mit Anzahl 2
+      cy.get('.sr-filterbar__action--download').should('be.visible').and('contain', '2')
+
+      // Auswahl aufheben → Button verschwindet
+      cy.get('.sr-selbar__clear').click()
+      cy.get('.sr-filterbar__action--download').should('not.exist')
+    })
+
+    it('Klick auf "Download (N)" löst /api/download-zip mit ids aus', () => {
+      openFolder()
+      cy.intercept('GET', '**/api/download-zip*').as('zip')
+
+      cy.get('.sr-grid__item').eq(0).click({ ctrlKey: true })
+      cy.get('.sr-grid__item').eq(1).click({ ctrlKey: true })
+      cy.get('.sr-filterbar__action--download').click()
+
+      cy.wait('@zip').its('request.url').should('include', 'ids=')
+    })
+  })
+
+  // ── Guest-Share: Gating über allow_download ─────────────────────────────────
+  describe('Guest ohne allow_download', () => {
+    let token
+    before(() => {
+      login()
+      createShare({ permissions: 'view', guest_name: 'NoDownload' }).then(s => { token = s.token })
+    })
+    after(() => deleteShare(token))
+
+    it('zeigt KEINEN Download-Button in der Loupe', () => {
+      cy.visit(`${NC_URL}/index.php/apps/starrate/guest/${token}`)
+      cy.get('.sr-grid__item', { timeout: 15000 }).first().dblclick()
+      cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+      cy.get('.sr-loupe__download').should('not.exist')
+    })
+  })
+
+  describe('Guest mit allow_download', () => {
+    let token
+    before(() => {
+      login()
+      createShare({ permissions: 'view', guest_name: 'WithDownload', allow_download: true })
+        .then(s => { token = s.token })
+    })
+    after(() => deleteShare(token))
+
+    it('zeigt den Download-Button in der Loupe', () => {
+      cy.visit(`${NC_URL}/index.php/apps/starrate/guest/${token}`)
+      cy.get('.sr-grid__item', { timeout: 15000 }).first().dblclick()
+      cy.get('.sr-loupe', { timeout: 5000 }).should('be.visible')
+      cy.get('.sr-loupe__download').should('be.visible')
+    })
+  })
+})

--- a/tests/js/LoupeView.spec.js
+++ b/tests/js/LoupeView.spec.js
@@ -1,8 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import LoupeView from '../../src/components/LoupeView.vue'
 
-const images = [{ id: 1, name: 'a.jpg', rating: 0, color: null, pick: 'none' }]
+const images = [
+  { id: 1, name: 'a.jpg', rating: 0, color: null, pick: 'none' },
+  { id: 2, name: 'b.jpg', rating: 0, color: null, pick: 'none' },
+]
 
 function factory(props = {}) {
   return mount(LoupeView, {
@@ -14,6 +18,8 @@ function factory(props = {}) {
     },
   })
 }
+
+const pt = (x, y) => ({ clientX: x, clientY: y })
 
 describe('LoupeView Download-Button', () => {
   let wrapper
@@ -35,5 +41,88 @@ describe('LoupeView Download-Button', () => {
     await wrapper.find('.sr-loupe__download').trigger('click')
     expect(wrapper.emitted('download')).toBeTruthy()
     expect(wrapper.emitted('download')[0][0]).toMatchObject({ id: 1, name: 'a.jpg' })
+  })
+})
+
+describe('LoupeView Touch-Gesten', () => {
+  let wrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+    vi.useRealTimers()
+  })
+
+  it('Pinch mit zwei Fingern zoomt rein (committet auf Pinch-Modus)', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+    expect(wrapper.find('.sr-loupe__zoom-level').text()).toBe('Eingepasst')
+
+    // Zwei Finger 100px auseinander → auf 140px spreizen (ratio 1.4)
+    await el.trigger('touchstart', { touches: [pt(100, 100), pt(200, 100)] })
+    await el.trigger('touchmove', { touches: [pt(80, 100), pt(220, 100)] })
+
+    expect(wrapper.find('.sr-loupe__zoom-level').text()).toMatch(/%/)
+  })
+
+  it('zweiter Finger nach Wandern des ersten würgt den Pinch NICHT mehr ab', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+
+    // Erst ein Finger, der deutlich wandert (>30px — alter Abbruch-Fall) ...
+    await el.trigger('touchstart', { touches: [pt(100, 100)] })
+    await el.trigger('touchmove', { touches: [pt(150, 100)] })
+    // ... dann kommt der zweite Finger dazu → muss in Pinch-Modus wechseln
+    await el.trigger('touchstart', { touches: [pt(150, 100), pt(250, 100)] })
+    await el.trigger('touchmove', { touches: [pt(120, 100), pt(280, 100)] })
+
+    expect(wrapper.find('.sr-loupe__zoom-level').text()).toMatch(/%/)
+  })
+
+  it('Ein-Finger-Swipe im Fit navigiert weiter', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+
+    await el.trigger('touchstart', { touches: [pt(300, 100)] })
+    await el.trigger('touchend', { touches: [], changedTouches: [pt(100, 110)] })
+
+    expect(wrapper.emitted('index-change')).toBeTruthy()
+    expect(wrapper.emitted('index-change')[0][0]).toBe(1)
+  })
+
+  // v-show spiegelt sich als inline `display: none` — robuster als isVisible()
+  // (jsdom liefert keinen Stylesheet-Computed-Style → isVisible() false-negativ).
+  const footerHidden = () =>
+    (wrapper.find('.sr-loupe__footer').attributes('style') || '').includes('display: none')
+
+  it('Auto-Hide: Mausrad-Zoom blendet die Leiste nach 3s aus, Fit nicht', async () => {
+    vi.useFakeTimers()
+    wrapper = factory()
+
+    // Im Fit bleibt die Leiste sichtbar — auch nach Ablauf (kein Hide-Timer)
+    vi.advanceTimersByTime(3500)
+    await nextTick()
+    expect(footerHidden()).toBe(false)
+
+    // Reines Mausrad-Zoom (ohne mousemove) armiert jetzt den Hide-Timer
+    await wrapper.find('.sr-loupe').trigger('wheel', { deltaY: -100 })
+    expect(footerHidden()).toBe(false)
+
+    vi.advanceTimersByTime(3500)
+    await nextTick()
+    expect(footerHidden()).toBe(true)
+  })
+
+  it('Touch holt die ausgeblendete Leiste zurück', async () => {
+    vi.useFakeTimers()
+    wrapper = factory()
+
+    await wrapper.find('.sr-loupe').trigger('wheel', { deltaY: -100 })
+    vi.advanceTimersByTime(3500)
+    await nextTick()
+    expect(footerHidden()).toBe(true)
+
+    await wrapper.find('.sr-loupe').trigger('touchstart', { touches: [pt(100, 100)] })
+    await nextTick()
+    expect(footerHidden()).toBe(false)
   })
 })

--- a/tests/js/LoupeView.spec.js
+++ b/tests/js/LoupeView.spec.js
@@ -126,3 +126,23 @@ describe('LoupeView Touch-Gesten', () => {
     expect(footerHidden()).toBe(false)
   })
 })
+
+describe('LoupeView Doppelklick-Zoom', () => {
+  let wrapper
+  afterEach(() => wrapper?.unmount())
+
+  it('over-zoomt auf einen festen Faktor (formatunabhängig) und toggelt zurück auf Fit', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+    expect(wrapper.find('.sr-loupe__zoom-level').text()).toBe('Eingepasst')
+
+    // Fester Over-Zoom — unabhängig von Bildmaßen (jsdom hat keine), also gleicher
+    // Wert für Hoch- wie Querformat. Vorher rechnete naturalWidth/cw → formatabhängig.
+    await el.trigger('dblclick')
+    expect(wrapper.find('.sr-loupe__zoom-level').text()).toBe('300%')
+
+    // Zweiter Doppelklick → zurück auf Fit
+    await el.trigger('dblclick')
+    expect(wrapper.find('.sr-loupe__zoom-level').text()).toBe('Eingepasst')
+  })
+})

--- a/tests/js/LoupeView.spec.js
+++ b/tests/js/LoupeView.spec.js
@@ -102,6 +102,34 @@ describe('LoupeView Touch-Gesten', () => {
     expect(Math.abs(parseFloat(m[1]))).toBeLessThan(1)
   })
 
+  it('nach Pinch mit verbleibendem Finger weiter pannen (kein Freeze)', async () => {
+    wrapper = factory()
+    const loupeEl = wrapper.find('.sr-loupe').element
+    const imgEl   = wrapper.find('.sr-loupe__img').element
+    loupeEl.getBoundingClientRect = () => ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600 })
+    Object.defineProperty(loupeEl, 'offsetWidth',  { value: 800, configurable: true })
+    Object.defineProperty(loupeEl, 'offsetHeight', { value: 600, configurable: true })
+    Object.defineProperty(imgEl,   'naturalWidth',  { value: 4000, configurable: true })
+    Object.defineProperty(imgEl,   'naturalHeight', { value: 3000, configurable: true })
+
+    const panX = () => {
+      const m = (wrapper.find('.sr-loupe__img').attributes('style') || '')
+        .match(/translate\(calc\(-50% \+ ([-\d.]+)px\)/)
+      return m ? parseFloat(m[1]) : NaN
+    }
+
+    const el = wrapper.find('.sr-loupe')
+    // Pinch reinzoomen
+    await el.trigger('touchstart', { touches: [pt(300, 200), pt(500, 200)] })
+    await el.trigger('touchmove',  { touches: [pt(200, 200), pt(600, 200)] })
+    // Einen Finger heben → ein Finger bleibt
+    await el.trigger('touchend', { touches: [pt(400, 300)], changedTouches: [pt(600, 200)] })
+    const before = panX()
+    // Verbleibenden Finger ziehen → muss pannen (vorher: eingefroren)
+    await el.trigger('touchmove', { touches: [pt(460, 300)] })
+    expect(panX()).not.toBe(before)
+  })
+
   it('Ein-Finger-Swipe im Fit navigiert weiter', async () => {
     wrapper = factory()
     const el = wrapper.find('.sr-loupe')

--- a/tests/js/LoupeView.spec.js
+++ b/tests/js/LoupeView.spec.js
@@ -78,6 +78,30 @@ describe('LoupeView Touch-Gesten', () => {
     expect(wrapper.find('.sr-loupe__zoom-level').text()).toMatch(/%/)
   })
 
+  it('Pinch zoomt auf den Finger-Mittelpunkt (Pivot), nicht um die Bildmitte', async () => {
+    wrapper = factory()
+    const loupeEl = wrapper.find('.sr-loupe').element
+    const imgEl   = wrapper.find('.sr-loupe__img').element
+    // jsdom hat keine Layout-Maße → für die Pivot-Rechnung mocken.
+    loupeEl.getBoundingClientRect = () => ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600 })
+    Object.defineProperty(loupeEl, 'offsetWidth',  { value: 800, configurable: true })
+    Object.defineProperty(loupeEl, 'offsetHeight', { value: 600, configurable: true })
+    Object.defineProperty(imgEl,   'naturalWidth',  { value: 4000, configurable: true })
+    Object.defineProperty(imgEl,   'naturalHeight', { value: 3000, configurable: true })
+
+    // Pinch um Mittelpunkt (400,200) — horizontal mittig, oberhalb der Mitte (400,300).
+    const el = wrapper.find('.sr-loupe')
+    await el.trigger('touchstart', { touches: [pt(300, 200), pt(500, 200)] })
+    await el.trigger('touchmove',  { touches: [pt(200, 200), pt(600, 200)] })
+
+    const style = wrapper.find('.sr-loupe__img').attributes('style') || ''
+    const m = style.match(/translate\(calc\(-50% \+ ([-\d.]+)px\), calc\(-50% \+ ([-\d.]+)px\)/)
+    expect(m).toBeTruthy()
+    // Pivot oberhalb der Mitte → Bild rückt nach unten → panY > 0, panX ≈ 0
+    expect(parseFloat(m[2])).toBeGreaterThan(0)
+    expect(Math.abs(parseFloat(m[1]))).toBeLessThan(1)
+  })
+
   it('Ein-Finger-Swipe im Fit navigiert weiter', async () => {
     wrapper = factory()
     const el = wrapper.find('.sr-loupe')

--- a/tests/js/LoupeView.spec.js
+++ b/tests/js/LoupeView.spec.js
@@ -179,6 +179,57 @@ describe('LoupeView Touch-Gesten', () => {
   })
 })
 
+describe('LoupeView Doppeltipp (Touch)', () => {
+  let wrapper
+  afterEach(() => { wrapper?.unmount(); vi.useRealTimers() })
+
+  const label = () => wrapper.find('.sr-loupe__zoom-level').text()
+
+  // Ein stehender Tap an (x,y): touchstart + touchend ohne Bewegung.
+  async function tap(el, x = 400, y = 300) {
+    await el.trigger('touchstart', { touches: [pt(x, y)] })
+    await el.trigger('touchend', { touches: [], changedTouches: [pt(x, y)] })
+  }
+
+  it('zwei stehende Taps over-zoomen wie Doppelklick (Fit → 300%)', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+    expect(label()).toBe('Eingepasst')
+    await tap(el, 400, 300)
+    await tap(el, 402, 301)   // gleiche Stelle, sofort
+    expect(label()).toBe('300%')
+  })
+
+  it('Doppeltipp bei Zoom kehrt zu Fit zurück', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+    await tap(el); await tap(el)            // rein → 300%
+    expect(label()).toBe('300%')
+    await tap(el); await tap(el)            // raus → Fit
+    expect(label()).toBe('Eingepasst')
+  })
+
+  it('zwei schnelle Swipes lösen KEINEN Doppeltipp-Zoom aus', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+    for (let i = 0; i < 2; i++) {
+      await el.trigger('touchstart', { touches: [pt(300, 300)] })
+      await el.trigger('touchend', { touches: [], changedTouches: [pt(210, 300)] }) // dx=-90 → Swipe
+    }
+    expect(label()).toBe('Eingepasst')   // bleibt Fit, kein Zoom
+  })
+
+  it('zwei Taps mit >300ms Abstand zoomen NICHT (nur Einzeltaps)', async () => {
+    vi.useFakeTimers()
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+    await tap(el)
+    vi.advanceTimersByTime(400)
+    await tap(el)
+    expect(label()).toBe('Eingepasst')
+  })
+})
+
 describe('LoupeView Doppelklick-Zoom', () => {
   let wrapper
   afterEach(() => wrapper?.unmount())

--- a/tests/js/LoupeView.spec.js
+++ b/tests/js/LoupeView.spec.js
@@ -145,4 +145,22 @@ describe('LoupeView Doppelklick-Zoom', () => {
     await el.trigger('dblclick')
     expect(wrapper.find('.sr-loupe__zoom-level').text()).toBe('Eingepasst')
   })
+
+  it('Fit ist die Untergrenze: Rauszoomen unter Fit schnappt auf Eingepasst zurück', async () => {
+    wrapper = factory()
+    const el = wrapper.find('.sr-loupe')
+    const label = () => wrapper.find('.sr-loupe__zoom-level').text()
+
+    // Aus dem Fit heraus rauszoomen (deltaY > 0) bleibt Fit
+    await el.trigger('wheel', { deltaY: 100 })
+    expect(label()).toBe('Eingepasst')
+
+    // Reinzoomen funktioniert
+    await el.trigger('wheel', { deltaY: -100 })
+    expect(label()).toMatch(/%/)
+
+    // Mehrfach rauszoomen → schnappt auf Fit, nicht unter Fit
+    for (let i = 0; i < 12; i++) await el.trigger('wheel', { deltaY: 100 })
+    expect(label()).toBe('Eingepasst')
+  })
 })

--- a/tests/js/ZoomView.spec.js
+++ b/tests/js/ZoomView.spec.js
@@ -362,7 +362,7 @@ describe('LoupeView – Zoom & Navigation', () => {
 
   // ── Doppelklick ───────────────────────────────────────────────────────────
 
-  it('Doppelklick wechselt von Fit zu 100%', async () => {
+  it('Doppelklick wechselt von Fit zu Over-Zoom', async () => {
     const w = factory()
     await w.find('.sr-loupe').trigger('dblclick')
     const label = w.find('.sr-loupe__zoom-level').text()
@@ -553,11 +553,17 @@ describe('LoupeView – Zoom & Navigation', () => {
     await w.find('.sr-loupe').trigger('touchmove', {
       touches: [{ clientX: 150, clientY: 200 }, { clientX: 250, clientY: 200 }],
     })
-    const after = parseInt(w.find('.sr-loupe__zoom-level').text())
-    expect(after).toBeLessThan(before)
+    // Rauszoomen unter Fit schnappt auf Fit zurück (Fit ist die Untergrenze) —
+    // das ist gültiges Herauszoomen.
+    const after = w.find('.sr-loupe__zoom-level').text()
+    if (after.includes('Eingepasst')) {
+      expect(true).toBe(true)
+    } else {
+      expect(parseInt(after)).toBeLessThan(before)
+    }
   })
 
-  it('Zoom bleibt bei MIN_ZOOM (25%) gedeckelt', async () => {
+  it('Zoom-Untergrenze ist Fit — Rauszoomen geht nicht unter Eingepasst', async () => {
     const w = factory()
     // Erst reinzoomen, dann viele Male raus
     await w.find('.sr-loupe').trigger('wheel', { deltaY: -120 })
@@ -565,11 +571,8 @@ describe('LoupeView – Zoom & Navigation', () => {
     for (let i = 0; i < 30; i++) {
       await w.find('.sr-loupe').trigger('wheel', { deltaY: 120 })
     }
-    const label = w.find('.sr-loupe__zoom-level').text()
-    // Entweder Fit (Reset bei MIN_ZOOM-Nähe) oder >= 25%
-    if (!label.includes('Eingepasst')) {
-      expect(parseInt(label)).toBeGreaterThanOrEqual(25)
-    }
+    // Floor ist Fit: kein Sub-Fit-Zoom mehr, landet sauber auf Eingepasst
+    expect(w.find('.sr-loupe__zoom-level').text()).toContain('Eingepasst')
   })
 
   it('Rauszoomen im Fit-Modus per Mausrad wird ignoriert', async () => {

--- a/tests/js/ZoomView.spec.js
+++ b/tests/js/ZoomView.spec.js
@@ -553,14 +553,9 @@ describe('LoupeView – Zoom & Navigation', () => {
     await w.find('.sr-loupe').trigger('touchmove', {
       touches: [{ clientX: 150, clientY: 200 }, { clientX: 250, clientY: 200 }],
     })
-    // Rauszoomen unter Fit schnappt auf Fit zurück (Fit ist die Untergrenze) —
-    // das ist gültiges Herauszoomen.
-    const after = w.find('.sr-loupe__zoom-level').text()
-    if (after.includes('Eingepasst')) {
-      expect(true).toBe(true)
-    } else {
-      expect(parseInt(after)).toBeLessThan(before)
-    }
+    // ratio 0.5 aus ~156% landet unter Fit → schnappt auf Fit (die Untergrenze).
+    expect(before).toBeGreaterThan(100)
+    expect(w.find('.sr-loupe__zoom-level').text()).toContain('Eingepasst')
   })
 
   it('Zoom-Untergrenze ist Fit — Rauszoomen geht nicht unter Eingepasst', async () => {


### PR DESCRIPTION
## Loupe zoom & touch overhaul (1.3.8)

Reworks the Loupe viewer's gesture and zoom handling. Most of this addresses the mobile zoom problems reported in #86, plus several pre-existing desktop zoom-geometry bugs surfaced while testing.

### Touch (mobile)
- **Pinch** no longer stalls on random zoom levels: the gesture commits to pinch mode once two fingers are down (replaces a fragile 30px swipe-abort heuristic that could leave a gesture dead until release).
- **Pinch zooms toward the finger midpoint** (pivot) instead of the image center.
- **Pinch → one-finger drag**: lifting one finger after a pinch now hands off to single-finger panning instead of freezing.
- **Double-tap anywhere** toggles fit ⇄ over-zoom on the tap point — movement-gated, so a swipe (moves >60px) can never be mistaken for a tap. No collision with swipe navigation.
- Guard against `lastPinchDist === 0` (coincident touch points) producing a jump to max zoom.

### Zoom geometry (desktop + touch)
- **Double-click / double-tap = fixed over-zoom** relative to fit, identical for portrait and landscape and across FHD/tablet/4K (previously `naturalWidth / containerWidth`, which shrank portraits below fit and behaved orientation-dependently).
- **Correct pivot math** (`pan' = d − ratio·(d − pan)`, screen-space) so the point under the cursor stays fixed when zooming via wheel or double-click.
- **`constrainPan` uses the letterboxed displayed size** (`fitScale`) instead of raw natural dimensions → no pan drift, especially when zooming out.
- **Fit is the single zoom floor**: zooming out never goes below fit; wheel, keyboard and pinch all bottom out symmetrically at fit.

### Controls auto-hide
- The rating bar's auto-hide is now state-driven (re-armed on every zoom change incl. plain mouse-wheel, and on touch), fixing both unreliable hiding and the missing way to bring it back on mobile.

### Cleanup
- Shared `startPan`/`panTo` helpers (mouse + touch), removed dead reactive `touches` ref, simplified `onMouseDown` guard, trimmed comments.

### Also included
- `test(e2e)`: Cypress specs for image download (carried over from the 1.3.7 work, previously local-only).

### Tests
- Vitest: 463 passing (incl. new pinch-pivot, pinch→drag, double-tap, fit-floor, auto-hide coverage).
- ESLint clean, production build green.
- Manually verified on desktop and mobile (sixpack).

Refs #86. Preview resolution intentionally left unchanged (1920×1200).
